### PR TITLE
Add test cases of tables with multiple-column for gpapply

### DIFF
--- a/tests/testthat/test-gpapply.R
+++ b/tests/testthat/test-gpapply.R
@@ -7,58 +7,61 @@ context("Test matrix of gpapply")
 env <- new.env(parent = globalenv())
 #.dbname = get('pivotalr_dbname', envir=env)
 #.port = get('pivotalr_port', envir=env)
+.verbose <- FALSE
 
+.host <- 'localhost'
 .dbname <- "d_apply"
 .port <- 15432
 .language <- 'plr'
 ## connection ID
-cid <- db.connect(port = .port, dbname = .dbname, verbose = FALSE)
+cid <- db.connect(host = .host, port = .port, dbname = .dbname, verbose = .verbose)
 .nrow.test <- 10
-dat <- abalone[c(1:.nrow.test),]
+
+dat <- abalone[c(1:.nrow.test), ]
 
 tname.1.col <- 'one_Col_Table'
 tname.mul.col <- 'mul_Col_Table'
-db.q('DROP SCHEMA IF EXISTS test_Schema CASCADE;', verbose = FALSE)
-db.q('DROP SCHEMA IF EXISTS "test_Schema" CASCADE;', verbose = FALSE)
-db.q(paste('DROP TABLE IF EXISTS "', tname.1.col, '";', sep = ''), verbose = FALSE)
-db.q(paste('DROP TABLE IF EXISTS "', tname.mul.col, '";', sep = ''), verbose = FALSE)
+db.q('DROP SCHEMA IF EXISTS test_Schema CASCADE;', verbose = .verbose)
+db.q('DROP SCHEMA IF EXISTS "test_Schema" CASCADE;', verbose = .verbose)
+db.q(paste('DROP TABLE IF EXISTS "', tname.1.col, '";', sep = ''), verbose = .verbose)
+db.q(paste('DROP TABLE IF EXISTS "', tname.mul.col, '";', sep = ''), verbose = .verbose)
 
 # prepare test table
 .dat.1 <- as.data.frame(dat$height)
 names(.dat.1) <- c('height')
-.dat.mul <- dat
-dat.1.col <- as.db.data.frame(.dat.1, table.name = tname.1.col, verbose = FALSE)
-dat.mul.col <- as.db.data.frame(.dat.mul, table.name = tname.mul.col, verbose = FALSE)
+dat.1 <- as.db.data.frame(.dat.1, table.name = tname.1.col, verbose = .verbose)
+dat.mul <- as.db.data.frame(dat, table.name = tname.mul.col, verbose = .verbose)
 
-.signature <- list("Score" = "float")
-
-fn.inc <- function(x) {
-    return (x[1] + 1)
-}
 
 # ---------------------------------------------------------------
 # prepare data
 # ---------------------------------------------------------------
 test_that("Test prepare", {
     testthat::skip_on_cran()
-    expect_equal(is.db.data.frame(dat.1.col), TRUE)
-    expect_equal(is.db.data.frame(dat.mul.col), TRUE)
-    expect_equal(nrow(dat.1.col), .nrow.test)
-    expect_equal(ncol(dat.1.col), 1)
-    expect_equal(nrow(dat.mul.col), .nrow.test)
-    expect_equal(ncol(dat.mul.col), ncol(dat))
+    expect_equal(is.db.data.frame(dat.1), TRUE)
+    expect_equal(is.db.data.frame(dat.mul), TRUE)
+    expect_equal(nrow(dat.1), .nrow.test)
+    expect_equal(ncol(dat.1), 1)
+    expect_equal(nrow(dat.mul), .nrow.test)
+    expect_equal(ncol(dat.mul), ncol(dat))
 
     expect_equal(db.existsObject(tname.1.col, conn.id = cid), TRUE)
     expect_equal(db.existsObject(tname.mul.col, conn.id = cid), TRUE)
 
-    res <- db.q("CREATE SCHEMA test_Schema", verbose = FALSE)
+    res <- db.q("CREATE SCHEMA test_Schema", verbose = .verbose)
     expect_equal(res, NULL)
     res <- db.q("SELECT nspname FROM pg_namespace WHERE nspname = 'test_schema';",
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), 1)
 })
 
+# test table has only one column
+dat.test <- dat.1
+.signature <- list("Score" = "float")
+fn.inc <- function(x) {
+    return (x[1] + 1)
+}
 # ---------------------------------------------------------------
 # ONE COLUMN TABLE
 # ---------------------------------------------------------------
@@ -67,28 +70,28 @@ test_that("Test output.name is NULL", {
     .output.name <- NULL
 
     # case sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = TRUE, language = .language)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
-    expect_equal(ncol(res), ncol(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
+    expect_equal(ncol(res), ncol(dat.test))
 
     # case non-sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
-    expect_equal(ncol(res), ncol(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
+    expect_equal(ncol(res), ncol(dat.test))
 
     # clear.existing can be FALSE, or any other values, since output.name is NULL
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = FALSE, case.sensitive = TRUE, language = .language)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
-    expect_equal(ncol(res), ncol(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
+    expect_equal(ncol(res), ncol(dat.test))
 })
 
 # output.name is not NULL, and it is a single table name
@@ -96,27 +99,27 @@ test_that("Test output.name is a table name", {
     .output.name <- 'result_GPapply'
 
     # case sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = TRUE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM \"", .output.name,
                 "\" WHERE \"Score\" IS NOT NULL;", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
 
     # case non-sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE,
                     language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name,
                 " WHERE Score IS NOT NULL;", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
 })
 
 # output.name is not NULL, and it is a single table name
@@ -124,24 +127,24 @@ test_that("Test output.name is schema.table", {
     .output.name <- 'test_schema.resultGPapply'
 
     # case sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = TRUE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM \"test_schema\".\"resultGPapply\" WHERE \"Score\" IS NOT NULL;"),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
 
     # case non-sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name,
-                " WHERE Score IS NOT NULL;", sep = ""), verbose = FALSE)
+                " WHERE Score IS NOT NULL;", sep = ""), verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
 
 })
 
@@ -150,7 +153,7 @@ test_that("Test output.name is invalid name", {
     .output.names <- list('"ab"', '"b.c"', 'public.ab.cd')
     for(name in .output.names) {
         tryCatch({
-            db.gpapply(dat.1.col, output.name = name,
+            db.gpapply(dat.test, output.name = name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
             stop("can't be here")
@@ -168,7 +171,7 @@ test_that("Test output.signature", {
     # 0. output.signature is a list, skip.
     # 1. output.signature is NULL
     tryCatch({
-        res <- db.gpapply(dat.1.col, output.name = .output.name, FUN = fn.inc,
+        res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
                     output.signature = NULL)
         stop("shouldn't be here")
     }, error = function(e) {
@@ -177,18 +180,18 @@ test_that("Test output.signature", {
 
     # 2. output.signature is a function
     f.sig <- function() return(.signature)
-    res <- db.gpapply(dat.1.col, output.name = .output.name, FUN = fn.inc,
+    res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
                     output.signature = f.sig, clear.existing = TRUE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name,
-                " WHERE Score IS NOT NULL;", sep = ""), verbose = FALSE)
+                " WHERE Score IS NOT NULL;", sep = ""), verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
 
     # 3. data type is not supported
     tryCatch({
         f.sig <- function() return(list("Score" = "invalidType"))
-        res <- db.gpapply(dat.1.col, output.name = .output.name, FUN = fn.inc,
+        res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
                     output.signature = f.sig, clear.existing = TRUE, language = .language)
         stop("can't be here")
     }, error = function(e) {
@@ -196,7 +199,7 @@ test_that("Test output.signature", {
     })
     # 4. output.signature is any other invalid value
     tryCatch({
-        res <- db.gpapply(dat.1.col, output.name = .output.name, FUN = fn.inc,
+        res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
                     output.signature = list(), clear.existing = TRUE, language = .language)
         stop("can't be here")
     }, error = function(e) {
@@ -208,7 +211,7 @@ test_that("Test Function applyed to data", {
     # 0. FUN is NULL, or FUN is a simple function, skip
     # 1. FUN is a non-function
     tryCatch({
-        res <- db.gpapply(dat.1.col, output.name = NULL, output.signature = .signature,
+        res <- db.gpapply(dat.test, output.name = NULL, output.signature = .signature,
                         FUN = 'bad_function')
         stop("can't be here")
     }, error = function(e) {
@@ -216,17 +219,17 @@ test_that("Test Function applyed to data", {
     })
     # 2. FUN is an anonymous function
     .output.name <- 'test_FUNC'
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = function(x) x[1] + 1, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Score IS NOT NULL;", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
     # 3. FUN references outer environment
     tryCatch({
-        db.gpapply(dat.1.col, output.name = .output.name,
+        db.gpapply(dat.test, output.name = .output.name,
                     FUN = function(x) return(fn.inc(x)), output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
         stop("cann't be here")
@@ -237,46 +240,46 @@ test_that("Test Function applyed to data", {
 
 test_that("Test clear.existing", {
     .output.name <- 'tab_existing'
-    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = FALSE)
+    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = .verbose)
     res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname ='", .output.name, "';", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res) && nrow(res) == 0, TRUE)
 
     #0 clear.existing is TRUE, when the table doesn't exist (OK)
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                 FUN = fn.inc, output.signature = .signature,
                 clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
     #1 clear.existing is TRUE, when the table exists        (OK)
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                 FUN = fn.inc, output.signature = .signature,
                 clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
 
     #2 clear.existing is FALSE, when the table doesn't exist(OK)
     # clear existing table
-    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = FALSE)
+    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = .verbose)
     res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res) && nrow(res) == 0, TRUE)
 
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                 FUN = fn.inc, output.signature = .signature,
                 clear.existing = FALSE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
 
     #3 clear.existing is FALSE, when the table exists       (ERROR)
     tryCatch({
-        db.gpapply(dat.1.col, output.name = .output.name,
+        db.gpapply(dat.test, output.name = .output.name,
                 FUN = fn.inc, output.signature = .signature,
                 clear.existing = FALSE, case.sensitive = FALSE, language = .language)
         stop("can't be here")
@@ -292,33 +295,33 @@ test_that("Test clear.existing", {
 test_that("Test distributedOn", {
     .output.name <- 'testDistribute'
     # randomly
-    res <- db.gpapply(dat.1.col, output.name = .output.name, output.distributeOn = 'randomly',
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = 'randomly',
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Score IS NOT NULL;", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
     # replicated
-    res <- db.gpapply(dat.1.col, output.name = .output.name, output.distributeOn = 'replicated',
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = 'replicated',
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Score IS NOT NULL;", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
     # columns
     .sql <- "SELECT attname FROM pg_class, gp_distribution_policy gp, pg_attribute pa"
     .sql <- paste(.sql, " WHERE pg_class.oid=gp.localoid and pg_class.relname = '", sep = "")
     .sql <- paste(.sql, tolower(.output.name),
             "' and pa.attrelid=pg_class.oid and pa.attnum=ANY(gp.distkey);", sep = "")
-    res <- db.gpapply(dat.1.col, output.name = .output.name, output.distributeOn = list(names(.signature)[1]),
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = list(names(.signature)[1]),
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
-    res <- db.q(.sql, verbose = FALSE)
+    res <- db.q(.sql, verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), 1)
 })
@@ -334,7 +337,7 @@ test_that("Test additional junk parameters", {
         return (x[1] + 1)
     }
     # case sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = .func, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = TRUE,
                     language = .language, junk1 = 12, junk2 = "Hello",
@@ -342,9 +345,9 @@ test_that("Test additional junk parameters", {
     expect_equal(res, NULL)
     res <- db.q(paste('SELECT 1 FROM "', .output.name,
                 '" WHERE "Score" IS NOT NULL;', sep = ''),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
 
 })
 # --------------------------------------------------------
@@ -362,12 +365,12 @@ test_that("Test consistency of database objects", {
     q.func <- "SELECT count(1) FROM pg_proc WHERE proname like 'gprfunc_%';"
 
     q.type_func <- function() {
-        res <- db.q(q.type, verbose = FALSE)
-        expect_equal(is.data.frame(res) && nrow(res) == ncol(res), TRUE)
-        n.type <- nrow(res)
-        res <- db.q(q.func, verbose = FALSE)
-        expect_equal(is.data.frame(res) && nrow(res) == ncol(res), TRUE)
-        n.func <- nrow(res)
+        res <- db.q(q.type, verbose = .verbose)
+        expect_equal(is.data.frame(res), TRUE)
+        n.type <- res[1, 1]
+        res <- db.q(q.func, verbose = .verbose)
+        expect_equal(is.data.frame(res), TRUE)
+        n.func <- res[1, 1]
         return (list(type = n.type, func = n.func))
     }
     res <- q.type_func()
@@ -377,7 +380,7 @@ test_that("Test consistency of database objects", {
     tryCatch({
     .output.name <- 'testConsistency'
     .func <- function(x) stop("internal error by myself")
-    db.gpapply(dat.1.col, output.name = .output.name,
+    db.gpapply(dat.test, output.name = .output.name,
                     FUN = .func, output.signature = .signature,
                     clear.existing = TRUE, language = .language)
     stop("can't be here")
@@ -393,7 +396,338 @@ test_that("Test consistency of database objects", {
 # --------------------------------------------------------------------------
 # MULTIPLE COLUMNS TABLE
 # --------------------------------------------------------------------------
+dat.test <- dat.mul
+# columns as the output table
+.col.chooser <- c(1, 2, 3, 5, 9)
+.signature <- list(id = 'int', sex = 'text', length = 'float', height = 'float', shell = 'float')
+fn.inc <- function(x)
+{
+    x$length <- x$length + 1
+    x$height <- x$height - 1
+    return (x[, .col.chooser])
+}
+# output.name is NULL
+test_that("MT-Test output.name is NULL", {
+    .output.name <- NULL
+    # case sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE, language = .language)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    expect_equal(ncol(res), length(.signature))
+
+    # case non-sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    expect_equal(ncol(res), length(.signature))
+
+    # clear.existing can be FALSE, or any other values, since output.name is NULL
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = FALSE, case.sensitive = TRUE, language = .language)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    expect_equal(ncol(res), length(.signature))
+})
+
+# output.name is not NULL, and it is a single table name
+test_that("MT-Test output.name is a table name", {
+    .output.name <- 'result_GPapply'
+
+    # case sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM \"", .output.name,
+                "\" WHERE \"Score\" IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+
+    # case non-sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE,
+                    language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name,
+                " WHERE Score IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+})
+
+# output.name is not NULL, and it is a single table name
+test_that("MT-Test output.name is schema.table", {
+    .output.name <- 'test_schema.resultGPapply'
+
+    # case sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM \"test_schema\".\"resultGPapply\" WHERE \"Score\" IS NOT NULL;"),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+
+    # case non-sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name,
+                " WHERE Score IS NOT NULL;", sep = ""), verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+
+})
+
+test_that("MT-Test output.name is invalid name", {
+    # TODO: this invalid parameter should throw an exception
+    .output.names <- list('"ab"', '"b.c"', 'public.ab.cd')
+    for(name in .output.names) {
+        tryCatch({
+            db.gpapply(dat.test, output.name = name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+            stop("can't be here")
+        }, error = function(e) {
+            expect_match(as.character(e), "invalid output.name:")
+        })
+    }
+})
+
+# -------------------------------------------------------------------------
+# output.signature
+# -------------------------------------------------------------------------
+test_that("MT-Test output.signature", {
+    .output.name <- 'aBc'
+    # 0. output.signature is a list, skip.
+    # 1. output.signature is NULL
+    tryCatch({
+        res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
+                    output.signature = NULL)
+        stop("shouldn't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "NULL signature, not impl")
+    })
+
+    # 2. output.signature is a function
+    f.sig <- function() return(.signature)
+    res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
+                    output.signature = f.sig, clear.existing = TRUE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name,
+                " WHERE Score IS NOT NULL;", sep = ""), verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+
+    # 3. data type is not supported
+    tryCatch({
+        f.sig <- function()
+            return(list(id = 'int', sex = 'text', length = 'invalidtype', height = 'float', shell = 'float'))
+        res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
+                    output.signature = f.sig, clear.existing = TRUE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), 'ERROR:  type "invalidtype" does not exist')
+    })
+    # 4. output.signature is any other invalid value
+    tryCatch({
+        res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
+                    output.signature = list(), clear.existing = TRUE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), 'ERROR:  ')
+    })
+})
+
+test_that("MT-Test Function applyed to data", {
+    # 0. FUN is NULL, or FUN is a simple function, skip
+    # 1. FUN is a non-function
+    tryCatch({
+        res <- db.gpapply(dat.test, output.name = NULL, output.signature = .signature,
+                        FUN = 'bad_function')
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "FUN must be a function")
+    })
+    # 2. FUN is an anonymous function
+    .output.name <- 'test_FUNC'
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = function(x) x[, .col.chooser], output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Score IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    # 3. FUN references outer environment
+    tryCatch({
+        db.gpapply(dat.test, output.name = .output.name,
+                    FUN = function(x) return(fn.inc(x)), output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+        stop("cann't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "ERROR:  R interpreter expression evaluation error")
+    })
+})
+
+test_that("MT-Test clear.existing", {
+    .output.name <- 'tab_existing'
+    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = .verbose)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname ='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 0, TRUE)
+
+    #0 clear.existing is TRUE, when the table doesn't exist (OK)
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
+    #1 clear.existing is TRUE, when the table exists        (OK)
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
+
+    #2 clear.existing is FALSE, when the table doesn't exist(OK)
+    # clear existing table
+    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = .verbose)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 0, TRUE)
+
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = FALSE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
+
+    #3 clear.existing is FALSE, when the table exists       (ERROR)
+    tryCatch({
+        db.gpapply(dat.test, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = FALSE, case.sensitive = FALSE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "the output table exists, but clear flag is not")
+    })
+})
+
+# -----------------------------------------------------
+# Skip case.sensitive, since it is fully tested
+# -----------------------------------------------------
+
+test_that("MT-Test distributedOn", {
+    .output.name <- 'testDistribute'
+    # randomly
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = 'randomly',
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Score IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    # replicated
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = 'replicated',
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Score IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    # columns
+    .sql <- "SELECT attname FROM pg_class, gp_distribution_policy gp, pg_attribute pa"
+    .sql <- paste(.sql, " WHERE pg_class.oid=gp.localoid and pg_class.relname = '", sep = "")
+    .sql <- paste(.sql, tolower(.output.name),
+            "' and pa.attrelid=pg_class.oid and pa.attnum=ANY(gp.distkey);", sep = "")
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = list(names(.signature)[c(1:3)]),
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(.sql, verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), 3)
+})
+
+test_that("MT-Test additional junk parameters", {
+    .output.name <- 'testJunkParameter'
+    .func <- function(x, junk1, junk2, junk3) {
+        return (fn.inc(x))
+    }
+    # case sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = .func, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE,
+                    language = .language, junk1 = 12, junk2 = "Hello",
+                    junk3 = list(id = 1, name = "world"))
+    expect_equal(res, NULL)
+    res <- db.q(paste('SELECT 1 FROM "', .output.name,
+                '" WHERE "Score" IS NOT NULL;', sep = ''),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+
+})
+# --------------------------------------------------------
+# consistency of database objects
+# --------------------------------------------------------
+# the whole/most steps are
+# Create Type => Create Function => Drop existing Table
+#   => Create Table => Drop Type & Function
+#
+# When the function gpapply/gptapply returns success or with error,
+# we should Run `DROP TYPE IF EXISTS "<GPTYPE>" CASCADE;`
+# The created function is always dropped as a dependency of gptype_xxx.
+test_that("MT-Test consistency of database objects", {
+    q.type <- "SELECT count(1) FROM pg_type WHERE typname like 'gptype_%';"
+    q.func <- "SELECT count(1) FROM pg_proc WHERE proname like 'gprfunc_%';"
+
+    q.type_func <- function() {
+        res <- db.q(q.type, verbose = .verbose)
+        expect_equal(is.data.frame(res), TRUE)
+        n.type <- res[1, 1]
+        res <- db.q(q.func, verbose = .verbose)
+        expect_equal(is.data.frame(res), TRUE)
+        n.func <- res[1, 1]
+        return (list(type = n.type, func = n.func))
+    }
+    res <- q.type_func()
+    old.type <- res$type
+    old.func <- res$func
+
+    tryCatch({
+    .output.name <- 'testConsistency'
+    .func <- function(x) stop("internal error by myself")
+    db.gpapply(dat.test, output.name = .output.name,
+                    FUN = .func, output.signature = .signature,
+                    clear.existing = TRUE, language = .language)
+    stop("can't be here")
+    }, error = function(e) {
+    }, finally = {
+        res <- q.type_func()
+        expect_equal(old.type, res$type)
+        expect_equal(old.func, res$func)
+    })
+
+})
 
 
-
-db.disconnect(cid, verbose = FALSE)
+db.disconnect(cid, verbose = .verbose)

--- a/tests/testthat/test-gpapply.R
+++ b/tests/testthat/test-gpapply.R
@@ -399,12 +399,12 @@ test_that("Test consistency of database objects", {
 dat.test <- dat.mul
 # columns as the output table
 .col.chooser <- c(1, 2, 3, 5, 9)
-.signature <- list(id = 'int', sex = 'text', length = 'float', height = 'float', shell = 'float')
+.signature <- list(id = 'int', 'Sex' = 'text', 'Length' = 'float', height = 'float', shell = 'float')
 fn.inc <- function(x)
 {
     x$length <- x$length + 1
     x$height <- x$height - 1
-    return (x[, .col.chooser])
+    return (x[, c(1, 2, 3, 5, 9)])
 }
 # output.name is NULL
 test_that("MT-Test output.name is NULL", {
@@ -444,7 +444,7 @@ test_that("MT-Test output.name is a table name", {
                     clear.existing = TRUE, case.sensitive = TRUE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM \"", .output.name,
-                "\" WHERE \"Score\" IS NOT NULL;", sep = ""),
+                "\" WHERE \"Length\" IS NOT NULL;", sep = ""),
                 verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), nrow(dat.test))
@@ -456,7 +456,7 @@ test_that("MT-Test output.name is a table name", {
                     language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name,
-                " WHERE Score IS NOT NULL;", sep = ""),
+                " WHERE Length IS NOT NULL;", sep = ""),
                 verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), nrow(dat.test))
@@ -471,7 +471,7 @@ test_that("MT-Test output.name is schema.table", {
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = TRUE, language = .language)
     expect_equal(res, NULL)
-    res <- db.q(paste("SELECT 1 FROM \"test_schema\".\"resultGPapply\" WHERE \"Score\" IS NOT NULL;"),
+    res <- db.q(paste("SELECT 1 FROM \"test_schema\".\"resultGPapply\" WHERE \"Length\" IS NOT NULL;"),
                 verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), nrow(dat.test))
@@ -482,7 +482,7 @@ test_that("MT-Test output.name is schema.table", {
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name,
-                " WHERE Score IS NOT NULL;", sep = ""), verbose = .verbose)
+                " WHERE Length IS NOT NULL;", sep = ""), verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), nrow(dat.test))
 
@@ -524,7 +524,7 @@ test_that("MT-Test output.signature", {
                     output.signature = f.sig, clear.existing = TRUE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name,
-                " WHERE Score IS NOT NULL;", sep = ""), verbose = .verbose)
+                " WHERE Length IS NOT NULL;", sep = ""), verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), nrow(dat.test))
 
@@ -561,10 +561,10 @@ test_that("MT-Test Function applyed to data", {
     # 2. FUN is an anonymous function
     .output.name <- 'test_FUNC'
     res <- db.gpapply(dat.test, output.name = .output.name,
-                    FUN = function(x) x[, .col.chooser], output.signature = .signature,
+                    FUN = function(x) x[, c(1, 2, 3, 5, 9)], output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
-    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Score IS NOT NULL;", sep = ""),
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Length IS NOT NULL;", sep = ""),
                 verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), nrow(dat.test))
@@ -640,7 +640,7 @@ test_that("MT-Test distributedOn", {
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
-    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Score IS NOT NULL;", sep = ""),
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Length IS NOT NULL;", sep = ""),
                 verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), nrow(dat.test))
@@ -649,7 +649,7 @@ test_that("MT-Test distributedOn", {
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
-    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Score IS NOT NULL;", sep = ""),
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Length IS NOT NULL;", sep = ""),
                 verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), nrow(dat.test))
@@ -658,7 +658,7 @@ test_that("MT-Test distributedOn", {
     .sql <- paste(.sql, " WHERE pg_class.oid=gp.localoid and pg_class.relname = '", sep = "")
     .sql <- paste(.sql, tolower(.output.name),
             "' and pa.attrelid=pg_class.oid and pa.attnum=ANY(gp.distkey);", sep = "")
-    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = list(names(.signature)[c(1:3)]),
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = as.list(names(.signature)[c(1:3)]),
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
@@ -670,7 +670,9 @@ test_that("MT-Test distributedOn", {
 test_that("MT-Test additional junk parameters", {
     .output.name <- 'testJunkParameter'
     .func <- function(x, junk1, junk2, junk3) {
-        return (fn.inc(x))
+        x$length <- x$length + 1
+        x$height <- x$height - 1
+        return (x[, c(1, 2, 3, 5, 9)])
     }
     # case sensitive
     res <- db.gpapply(dat.test, output.name = .output.name,
@@ -680,7 +682,7 @@ test_that("MT-Test additional junk parameters", {
                     junk3 = list(id = 1, name = "world"))
     expect_equal(res, NULL)
     res <- db.q(paste('SELECT 1 FROM "', .output.name,
-                '" WHERE "Score" IS NOT NULL;', sep = ''),
+                '" WHERE "Length" IS NOT NULL;', sep = ''),
                 verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), nrow(dat.test))


### PR DESCRIPTION
In previous test cases, it only tests tables with one column, and return one column.
This PR test tables with multiple columns. For example, distributed by multiple columns.