### PR TITLE
Enhance gptapply. Add test cases for gptapply and gpapply.

### DIFF
--- a/R/db.gptapply.R
+++ b/R/db.gptapply.R
@@ -1,119 +1,137 @@
 # GPTapply
-
+# Must handle if the value of INDEX is case-sensitive
 .index.translate <- function(INDEX, ar)
 {
     if (is.null(INDEX))
         stop("INDEX value cannot be NULL")
-    if (is.integer(INDEX) || (is.double(INDEX) && floor(INDEX) == INDEX))
-        return (ar$.col.name[INDEX])
-    if (is.character(INDEX))
-        return (INDEX)
-    stop("INDEX value cannot be determined with value of type ", typeof(INDEX))
-}
-
-#.generate.gptapply.query <- function(output.name, funName, param.name.list, param.group.list, relation_name, INDEX, typeName, output.distributeOn, clear.existing){
-#    if (is.null(output.name))
-#    {
-#        query <- sprintf("WITH gpdbtmpa AS (\nSELECT (%s(%s)) AS gpdbtmpb FROM (SELECT %s FROM %s GROUP BY %s) tmptbl\n)\nSELECT (gpdbtmpb::%s).* FROM gpdbtmpa;",
-#                funName, param.name.list, param.group.list, relation_name, INDEX, typeName)
-#    }
-#    else
-#    {
-#        #add distributeOn
-#        query <- sprintf("CREATE TABLE %s AS\nWITH gpdbtmpa AS (\nSELECT (%s(%s)) AS gpdbtmpb FROM (SELECT %s FROM %s GROUP BY %s) tmptbl\n)\nSELECT (gpdbtmpb::%s).* FROM gpdbtmpa %s;",
-#                output.name, funName, param.name.list, param.group.list, relation_name, INDEX, typeName, .distribute.str(output.distributeOn))
-#        clearStmt <- .clear.existing.table(output.name, clear.existing)
-#        if (nchar(clearStmt) > 0)
-#                    query <- paste(clearStmt, query)
-#    }
-#
-#    return (query)
-#}
+    if (is.integer(INDEX) || (is.double(INDEX) && floor(INDEX) == INDEX)){
+        if ((INDEX <= length(ar$.col.name)) && (INDEX >= 1))
+            return (ar$.col.name[INDEX])
+        else
+            stop("INDEX value cannot exceed number of columns in current df")
+    }  
+    if (!is.character(INDEX))
+        stop("INDEX value cannot be determined with value of type ", typeof(INDEX))
+    # Take care: the INDEX may be case-sensitive
+    index <- tolower(INDEX)
+    if (index != INDEX) {
+        # not lower case, may case-sensitive
+        if (INDEX %in% ar$.col.name)
+            return (INDEX)
+    }
+    if (index %in% ar$.col.name)
+        return (index)
+        stop(paste("invalid INDEX value:", INDEX))
+    }
 
 
+# these SQLs may be executed.
+# 1. CREATE TYPE gptype_xxx
+# 2. CREATE FUNCTION gprfunc_xxx
+# 3. Execute the r-wrapper-function
+# 4. DROP TYPE gptype_xxx CASCADE
 db.gptapply <- function(X, INDEX, FUN = NULL, output.name = NULL, output.signature = NULL, clear.existing = FALSE, case.sensitive = FALSE,
         output.distributeOn = NULL, debugger.mode = FALSE, simplify = TRUE, runtime.id = "plc_r_shared", language = "plcontainer", ...)
 {
 
-    randomName <- getRandomNameList()
+    if (is.null(X) || !is.db.data.frame(X))
+        stop("X must be a db.data.frame")
+    if (!is.function(FUN))
+        stop("FUN must be a function")
+    .check.output.name(output.name)
+    .check.language(language)
 
-    #create type
-    typeName <- sprintf("gptype_%s", randomName)
-    if (is.null(output.signature)) {
-        # signature is null
-        stop("output.signature is null")
-    } else {
-        create_type_str <- .create.type.sql(typeName, output.signature, case.sensitive)
-        db.q(create_type_str)
-    }
-
+    basename <- getRandomNameList()
     # generate function parameter str
-    ar <- attributes(X)
-    param.type.list <- ""
-    param.group.list <- ""
-    relation_name <- ar$.content
 
-    param.name.list <- paste(ar$.col.name, collapse = ", ")
-
-    if (case.sensitive) {
-        if (!is.null(output.name))
-            output.name <-  paste('"', output.name, '"', sep = '')
-        ar$.col.name <- paste('"', ar$.col.name, '"', sep = '')
+    #create returned type if output.signature is not null
+    typeName <- .to.type.name(basename)
+    if (is.null(output.signature)) {
+        # TODO: signaturee is null
+        stop("NULL signature, not impl")
+    } else {
+        create_type_str <- .create.type.sql(typeName, output.signature, case.sensitive = case.sensitive)
+        db.q(create_type_str, verbose = FALSE)
     }
 
-    INDEX <- .index.translate(INDEX, ar)
-    upperIndex <- toupper(INDEX)
-    for (i in 1:length(ar$.col.name)) {
-        if (i > 1) {
-            if (toupper(ar$.col.name[i]) == upperIndex) {
-                param.group.list <- paste(param.group.list, ", ", ar$.col.name[i], sep = "")
-                param.type.list <- paste(param.type.list, ", ", ar$.col.name[i], " ", ar$.col.udt_name[i], sep = "")
-            }
-            else {
-                param.group.list <- paste(param.group.list, " , array_agg(", ar$.col.name[i], ") AS ", ar$.col.name[i], sep = "")
-                param.type.list <- paste(param.type.list, ", ", ar$.col.name[i], " ", ar$.col.udt_name[i], "[]", sep = "")
+    tryCatch({
+        ar <- attributes(X)
+        relation_name <- ar$.content
+        param.name.list <- paste(ar$.col.name, collapse = ", ")
+        if (isTRUE(case.sensitive)) {
+            if (!is.null(output.name))
+                output.name <-  paste('"', unlist(strsplit(output.name, '\\.')),'"', sep='', collapse='.')
+        } else {
+            # if not case sensitive, all default names created by postgresql are lower case
+            if (!is.null(output.name))
+                output.name <- tolower(output.name)
+        }
+        field.names <- paste('"', ar$.col.name, '"', sep = '')
+        INDEX <- .index.translate(INDEX, ar)
+        
+        .to.type.field <- function(col.name, udt.name, isIndex) {
+            return (paste('"', col.name, '" ', udt.name,
+                        ifelse(isIndex, '', '[]'), sep = ''))
+        }
+        .to.group.field <- function(col.name, isIndex) {
+            if (!isIndex)
+                return (paste('array_agg("', col.name, '") AS ', col.name, sep = ''))
+            if (tolower(col.name) == col.name)
+                return (col.name)
+            return (paste('"', col.name, '" AS ', col.name, sep = ''))
+        }
+        
+        # param.type.list used as the input parameters of the created function
+        # parameter names should be double quoted, so they are case-sensitive
+        param.type.list <- ""
+        param.group.list <- ""
+        for (i in 1:length(ar$.col.name)) {
+            if (i > 1) {
+                .isIndex <- (ar$.col.name[i] == INDEX)
+                param.group.list <- paste(param.group.list, ", ", 
+                                    .to.group.field(ar$.col.name[i], .isIndex), sep = "")
+                param.type.list <- paste(param.type.list, ", ",
+                                    .to.type.field(ar$.col.name[i], ar$.col.udt_name[i], .isIndex), sep = "")
+            } else {
+                .isIndex <- ar$.col.name[i] == INDEX
+                param.group.list <- .to.group.field(ar$.col.name[i], .isIndex)
+                param.type.list <- .to.type.field(ar$.col.name[i], ar$.col.udt_name[i], .isIndex)
             }
         }
-        else {
-            if (toupper(ar$.col.name[i]) == upperIndex) {
-                param.group.list <- paste(param.group.list, ar$.col.name[i], sep = "")
-                param.type.list <- paste(param.type.list, ar$.col.name[i], " ", ar$.col.udt_name[i], sep = "")
-            }
-            else {
-                param.group.list <- paste(param.group.list, "array_agg(", ar$.col.name[i], ") AS ", ar$.col.name[i], sep = "")
-                param.type.list <- paste(param.type.list, ar$.col.name[i], " ", ar$.col.udt_name[i], "[]", sep = "")
-            }
+        
+        #Create function
+        createStmt <- .create.r.wrapper2(basename = basename, FUN = FUN, 
+                                    selected.type.list = param.type.list,
+                                    # selected column from table X, it may be optimized
+                                    selected.equal.list = .selected.equal.list(ar$.col.name),
+                                    args = list(...), runtime.id = runtime.id,
+                                    language = language)
+        db.q(createStmt, verbose = FALSE)
+
+        index <- paste('"', INDEX, '"', sep = '')
+        funName <- .to.func.name(basename)
+        if (is.null(output.name))
+        {
+            query <- sprintf("WITH gpdbtmpa AS (\nSELECT (%s(%s)) AS gpdbtmpb FROM (SELECT %s FROM %s GROUP BY %s) tmptbl\n)\nSELECT (gpdbtmpb::%s).* FROM gpdbtmpa;",
+                    funName, param.name.list, param.group.list, relation_name, index, typeName)
         }
-    }
-    #print(param.name.list)
-    #print(param.group.list)
+        else
+        {
+            query <- sprintf("CREATE TABLE %s AS\nWITH gpdbtmpa AS (\nSELECT (%s(%s)) AS gpdbtmpb FROM (SELECT %s FROM %s GROUP BY %s) tmptbl\n)\nSELECT (gpdbtmpb::%s).* FROM gpdbtmpa %s;",
+                    output.name, funName, param.name.list, param.group.list, relation_name, index, typeName, 
+                    .distribute.str(output.distributeOn, case.sensitive = case.sensitive))
+            clearStmt <- .clear.existing.table(output.name, clear.existing)
+            if (nchar(clearStmt) > 0)
+                        query <- paste(clearStmt, query)
+        }
+        results <- db.q(query, nrows = NULL, verbose = FALSE)
 
-    createStmt <- .create.r.wrapper(randomName, FUN = FUN, col.names = ar$.col.name, param.list.str = param.type.list,
-                    args = list(...), runtime.id = runtime.id, language = language)
-    #print(createStmt)
-    db.q(createStmt)
-
-    # STEP: Create SQL
-    funName <- paste('gprfunc_', randomName, sep = '')
-    if (is.null(output.name))
-    {
-        query <- sprintf("WITH gpdbtmpa AS (\nSELECT (%s(%s)) AS gpdbtmpb FROM (SELECT %s FROM %s GROUP BY %s) tmptbl\n)\nSELECT (gpdbtmpb::%s).* FROM gpdbtmpa;",
-                funName, param.name.list, param.group.list, relation_name, INDEX, typeName)
-    }
-    else
-    {
-        query <- sprintf("CREATE TABLE %s AS\nWITH gpdbtmpa AS (\nSELECT (%s(%s)) AS gpdbtmpb FROM (SELECT %s FROM %s GROUP BY %s) tmptbl\n)\nSELECT (gpdbtmpb::%s).* FROM gpdbtmpa %s;",
-                output.name, funName, param.name.list, param.group.list, relation_name, INDEX, typeName)
-        clearStmt <- .clear.existing.table(output.name, clear.existing)
-        if (nchar(clearStmt) > 0)
-                    query <- paste(clearStmt, query)
-    }
-    #print(query)
-    results <- db.q(query, nrows = NULL)
-
-    # STEP: Do cleanup
-    cleanString <- sprintf("DROP TYPE %s CASCADE;",typeName)
-    db.q(cleanString)
+    #END OF tryCatch
+    }, finally = {
+        # STEP: Do cleanup
+        cleanString <- sprintf("DROP TYPE %s CASCADE;", typeName)
+        db.q(cleanString, verbose = FALSE)
+    })
 
     return (results)
 }

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -8,10 +8,12 @@ env <- new.env(parent = globalenv())
 #.dbname = get('pivotalr_dbname', envir=env)
 #.port = get('pivotalr_port', envir=env)
 
-.dbname = "rtest"
-.port = 15432
+.host <- '172.17.0.1'
+.host <- 'localhost'
+.dbname <- "rtest"
+.port <- 15432
 ## connection ID
-cid <- db.connect(port = .port, dbname = .dbname, verbose = FALSE)
+cid <- db.connect(host = .host, port = .port, dbname = .dbname, verbose = FALSE)
 
 ## data in the database
 dat <- as.db.data.frame(abalone, conn.id = cid, verbose = FALSE)

--- a/tests/testthat/test-gpapply.R
+++ b/tests/testthat/test-gpapply.R
@@ -7,58 +7,66 @@ context("Test matrix of gpapply")
 env <- new.env(parent = globalenv())
 #.dbname = get('pivotalr_dbname', envir=env)
 #.port = get('pivotalr_port', envir=env)
+.verbose <- FALSE
 
+.host <- '172.17.0.1'
+.host <- 'localhost'
 .dbname <- "d_apply"
 .port <- 15432
 .language <- 'plr'
 ## connection ID
-cid <- db.connect(port = .port, dbname = .dbname, verbose = FALSE)
+cid <- db.connect(host = .host, port = .port, dbname = .dbname, verbose = .verbose)
 .nrow.test <- 10
-dat <- abalone[c(1:.nrow.test),]
+
+dat <- abalone[c(1:.nrow.test), ]
 
 tname.1.col <- 'one_Col_Table'
 tname.mul.col <- 'mul_Col_Table'
-db.q('DROP SCHEMA IF EXISTS test_Schema CASCADE;', verbose = FALSE)
-db.q('DROP SCHEMA IF EXISTS "test_Schema" CASCADE;', verbose = FALSE)
-db.q(paste('DROP TABLE IF EXISTS "', tname.1.col, '";', sep = ''), verbose = FALSE)
-db.q(paste('DROP TABLE IF EXISTS "', tname.mul.col, '";', sep = ''), verbose = FALSE)
+db.q('DROP SCHEMA IF EXISTS test_Schema CASCADE;', verbose = .verbose)
+db.q('DROP SCHEMA IF EXISTS "test_Schema" CASCADE;', verbose = .verbose)
+db.q(paste('DROP TABLE IF EXISTS "', tname.1.col, '";', sep = ''), verbose = .verbose)
+db.q(paste('DROP TABLE IF EXISTS "', tname.mul.col, '";', sep = ''), verbose = .verbose)
 
 # prepare test table
 .dat.1 <- as.data.frame(dat$height)
-names(.dat.1) <- c('height')
-.dat.mul <- dat
-dat.1.col <- as.db.data.frame(.dat.1, table.name = tname.1.col, verbose = FALSE)
-dat.mul.col <- as.db.data.frame(.dat.mul, table.name = tname.mul.col, verbose = FALSE)
+names(.dat.1) <- c('Height')
+dat.name <- names(dat)
+dat.name[2] <- toupper(dat.name[2])
+names(dat) <- dat.name
+dat.1 <- as.db.data.frame(.dat.1, table.name = tname.1.col, verbose = .verbose)
+dat.mul <- as.db.data.frame(dat, table.name = tname.mul.col, verbose = .verbose)
 
-.signature <- list("Score" = "float")
-
-fn.inc <- function(x) {
-    return (x[1] + 1)
-}
 
 # ---------------------------------------------------------------
 # prepare data
 # ---------------------------------------------------------------
 test_that("Test prepare", {
     testthat::skip_on_cran()
-    expect_equal(is.db.data.frame(dat.1.col), TRUE)
-    expect_equal(is.db.data.frame(dat.mul.col), TRUE)
-    expect_equal(nrow(dat.1.col), .nrow.test)
-    expect_equal(ncol(dat.1.col), 1)
-    expect_equal(nrow(dat.mul.col), .nrow.test)
-    expect_equal(ncol(dat.mul.col), ncol(dat))
+    expect_equal(is.db.data.frame(dat.1), TRUE)
+    expect_equal(is.db.data.frame(dat.mul), TRUE)
+    expect_equal(nrow(dat.1), .nrow.test)
+    expect_equal(ncol(dat.1), 1)
+    expect_equal(nrow(dat.mul), .nrow.test)
+    expect_equal(ncol(dat.mul), ncol(dat))
 
     expect_equal(db.existsObject(tname.1.col, conn.id = cid), TRUE)
     expect_equal(db.existsObject(tname.mul.col, conn.id = cid), TRUE)
 
-    res <- db.q("CREATE SCHEMA test_Schema", verbose = FALSE)
+    res <- db.q("CREATE SCHEMA test_Schema", verbose = .verbose)
     expect_equal(res, NULL)
     res <- db.q("SELECT nspname FROM pg_namespace WHERE nspname = 'test_schema';",
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), 1)
 })
 
+# test table has only one column
+dat.test <- dat.1
+.signature <- list("Score" = "float")
+fn.inc <- function(x)
+{
+    return (x[1] + 1)
+}
 # ---------------------------------------------------------------
 # ONE COLUMN TABLE
 # ---------------------------------------------------------------
@@ -67,28 +75,28 @@ test_that("Test output.name is NULL", {
     .output.name <- NULL
 
     # case sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = TRUE, language = .language)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
-    expect_equal(ncol(res), ncol(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
+    expect_equal(ncol(res), ncol(dat.test))
 
     # case non-sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
-    expect_equal(ncol(res), ncol(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
+    expect_equal(ncol(res), ncol(dat.test))
 
     # clear.existing can be FALSE, or any other values, since output.name is NULL
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = FALSE, case.sensitive = TRUE, language = .language)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
-    expect_equal(ncol(res), ncol(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
+    expect_equal(ncol(res), ncol(dat.test))
 })
 
 # output.name is not NULL, and it is a single table name
@@ -96,27 +104,27 @@ test_that("Test output.name is a table name", {
     .output.name <- 'result_GPapply'
 
     # case sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = TRUE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM \"", .output.name,
                 "\" WHERE \"Score\" IS NOT NULL;", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
 
     # case non-sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE,
                     language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name,
                 " WHERE Score IS NOT NULL;", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
 })
 
 # output.name is not NULL, and it is a single table name
@@ -124,24 +132,24 @@ test_that("Test output.name is schema.table", {
     .output.name <- 'test_schema.resultGPapply'
 
     # case sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = TRUE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM \"test_schema\".\"resultGPapply\" WHERE \"Score\" IS NOT NULL;"),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
 
     # case non-sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name,
-                " WHERE Score IS NOT NULL;", sep = ""), verbose = FALSE)
+                " WHERE Score IS NOT NULL;", sep = ""), verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
 
 })
 
@@ -150,7 +158,7 @@ test_that("Test output.name is invalid name", {
     .output.names <- list('"ab"', '"b.c"', 'public.ab.cd')
     for(name in .output.names) {
         tryCatch({
-            db.gpapply(dat.1.col, output.name = name,
+            db.gpapply(dat.test, output.name = name,
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
             stop("can't be here")
@@ -168,7 +176,7 @@ test_that("Test output.signature", {
     # 0. output.signature is a list, skip.
     # 1. output.signature is NULL
     tryCatch({
-        res <- db.gpapply(dat.1.col, output.name = .output.name, FUN = fn.inc,
+        res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
                     output.signature = NULL)
         stop("shouldn't be here")
     }, error = function(e) {
@@ -177,18 +185,18 @@ test_that("Test output.signature", {
 
     # 2. output.signature is a function
     f.sig <- function() return(.signature)
-    res <- db.gpapply(dat.1.col, output.name = .output.name, FUN = fn.inc,
+    res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
                     output.signature = f.sig, clear.existing = TRUE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name,
-                " WHERE Score IS NOT NULL;", sep = ""), verbose = FALSE)
+                " WHERE Score IS NOT NULL;", sep = ""), verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
 
     # 3. data type is not supported
     tryCatch({
         f.sig <- function() return(list("Score" = "invalidType"))
-        res <- db.gpapply(dat.1.col, output.name = .output.name, FUN = fn.inc,
+        res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
                     output.signature = f.sig, clear.existing = TRUE, language = .language)
         stop("can't be here")
     }, error = function(e) {
@@ -196,7 +204,7 @@ test_that("Test output.signature", {
     })
     # 4. output.signature is any other invalid value
     tryCatch({
-        res <- db.gpapply(dat.1.col, output.name = .output.name, FUN = fn.inc,
+        res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
                     output.signature = list(), clear.existing = TRUE, language = .language)
         stop("can't be here")
     }, error = function(e) {
@@ -208,7 +216,7 @@ test_that("Test Function applyed to data", {
     # 0. FUN is NULL, or FUN is a simple function, skip
     # 1. FUN is a non-function
     tryCatch({
-        res <- db.gpapply(dat.1.col, output.name = NULL, output.signature = .signature,
+        res <- db.gpapply(dat.test, output.name = NULL, output.signature = .signature,
                         FUN = 'bad_function')
         stop("can't be here")
     }, error = function(e) {
@@ -216,17 +224,17 @@ test_that("Test Function applyed to data", {
     })
     # 2. FUN is an anonymous function
     .output.name <- 'test_FUNC'
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = function(x) x[1] + 1, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Score IS NOT NULL;", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
     # 3. FUN references outer environment
     tryCatch({
-        db.gpapply(dat.1.col, output.name = .output.name,
+        db.gpapply(dat.test, output.name = .output.name,
                     FUN = function(x) return(fn.inc(x)), output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
         stop("cann't be here")
@@ -237,46 +245,46 @@ test_that("Test Function applyed to data", {
 
 test_that("Test clear.existing", {
     .output.name <- 'tab_existing'
-    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = FALSE)
+    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = .verbose)
     res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname ='", .output.name, "';", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res) && nrow(res) == 0, TRUE)
 
     #0 clear.existing is TRUE, when the table doesn't exist (OK)
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                 FUN = fn.inc, output.signature = .signature,
                 clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
     #1 clear.existing is TRUE, when the table exists        (OK)
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                 FUN = fn.inc, output.signature = .signature,
                 clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
 
     #2 clear.existing is FALSE, when the table doesn't exist(OK)
     # clear existing table
-    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = FALSE)
+    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = .verbose)
     res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res) && nrow(res) == 0, TRUE)
 
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                 FUN = fn.inc, output.signature = .signature,
                 clear.existing = FALSE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
 
     #3 clear.existing is FALSE, when the table exists       (ERROR)
     tryCatch({
-        db.gpapply(dat.1.col, output.name = .output.name,
+        db.gpapply(dat.test, output.name = .output.name,
                 FUN = fn.inc, output.signature = .signature,
                 clear.existing = FALSE, case.sensitive = FALSE, language = .language)
         stop("can't be here")
@@ -292,33 +300,33 @@ test_that("Test clear.existing", {
 test_that("Test distributedOn", {
     .output.name <- 'testDistribute'
     # randomly
-    res <- db.gpapply(dat.1.col, output.name = .output.name, output.distributeOn = 'randomly',
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = 'randomly',
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Score IS NOT NULL;", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
     # replicated
-    res <- db.gpapply(dat.1.col, output.name = .output.name, output.distributeOn = 'replicated',
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = 'replicated',
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
     res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Score IS NOT NULL;", sep = ""),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
     # columns
     .sql <- "SELECT attname FROM pg_class, gp_distribution_policy gp, pg_attribute pa"
     .sql <- paste(.sql, " WHERE pg_class.oid=gp.localoid and pg_class.relname = '", sep = "")
     .sql <- paste(.sql, tolower(.output.name),
             "' and pa.attrelid=pg_class.oid and pa.attnum=ANY(gp.distkey);", sep = "")
-    res <- db.gpapply(dat.1.col, output.name = .output.name, output.distributeOn = list(names(.signature)[1]),
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = list(names(.signature)[1]),
                     FUN = fn.inc, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = FALSE, language = .language)
     expect_equal(res, NULL)
-    res <- db.q(.sql, verbose = FALSE)
+    res <- db.q(.sql, verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), 1)
 })
@@ -334,7 +342,7 @@ test_that("Test additional junk parameters", {
         return (x[1] + 1)
     }
     # case sensitive
-    res <- db.gpapply(dat.1.col, output.name = .output.name,
+    res <- db.gpapply(dat.test, output.name = .output.name,
                     FUN = .func, output.signature = .signature,
                     clear.existing = TRUE, case.sensitive = TRUE,
                     language = .language, junk1 = 12, junk2 = "Hello",
@@ -342,9 +350,9 @@ test_that("Test additional junk parameters", {
     expect_equal(res, NULL)
     res <- db.q(paste('SELECT 1 FROM "', .output.name,
                 '" WHERE "Score" IS NOT NULL;', sep = ''),
-                verbose = FALSE)
+                verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
-    expect_equal(nrow(res), nrow(dat.1.col))
+    expect_equal(nrow(res), nrow(dat.test))
 
 })
 # --------------------------------------------------------
@@ -362,12 +370,12 @@ test_that("Test consistency of database objects", {
     q.func <- "SELECT count(1) FROM pg_proc WHERE proname like 'gprfunc_%';"
 
     q.type_func <- function() {
-        res <- db.q(q.type, verbose = FALSE)
-        expect_equal(is.data.frame(res) && nrow(res) == ncol(res), TRUE)
-        n.type <- nrow(res)
-        res <- db.q(q.func, verbose = FALSE)
-        expect_equal(is.data.frame(res) && nrow(res) == ncol(res), TRUE)
-        n.func <- nrow(res)
+        res <- db.q(q.type, verbose = .verbose)
+        expect_equal(is.data.frame(res), TRUE)
+        n.type <- res[1, 1]
+        res <- db.q(q.func, verbose = .verbose)
+        expect_equal(is.data.frame(res), TRUE)
+        n.func <- res[1, 1]
         return (list(type = n.type, func = n.func))
     }
     res <- q.type_func()
@@ -377,7 +385,7 @@ test_that("Test consistency of database objects", {
     tryCatch({
     .output.name <- 'testConsistency'
     .func <- function(x) stop("internal error by myself")
-    db.gpapply(dat.1.col, output.name = .output.name,
+    db.gpapply(dat.test, output.name = .output.name,
                     FUN = .func, output.signature = .signature,
                     clear.existing = TRUE, language = .language)
     stop("can't be here")
@@ -393,7 +401,341 @@ test_that("Test consistency of database objects", {
 # --------------------------------------------------------------------------
 # MULTIPLE COLUMNS TABLE
 # --------------------------------------------------------------------------
+dat.test <- dat.mul
+# columns as the output table
+.col.chooser <- c(1, 2, 3, 5, 9)
+.signature <- list(id = 'int', 'Sex' = 'text', 'Length' = 'float', height = 'float', shell = 'float')
+fn.inc <- function(x)
+{
+    x$length <- x$length + 1
+    x$height <- x$height - 1
+    return (x[, c(1, 2, 3, 5, 9)])
+}
+# output.name is NULL
+test_that("MT-Test output.name is NULL", {
+    .output.name <- NULL
+    # case sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE, language = .language)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    expect_equal(ncol(res), length(.signature))
+
+    # case non-sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    expect_equal(ncol(res), length(.signature))
+
+    # clear.existing can be FALSE, or any other values, since output.name is NULL
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = FALSE, case.sensitive = TRUE, language = .language)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    expect_equal(ncol(res), length(.signature))
+})
+
+# output.name is not NULL, and it is a single table name
+test_that("MT-Test output.name is a table name", {
+    .output.name <- 'result_GPapply'
+
+    # case sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM \"", .output.name,
+                "\" WHERE \"Length\" IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+
+    # case non-sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE,
+                    language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name,
+                " WHERE Length IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+})
+
+# output.name is not NULL, and it is a single table name
+test_that("MT-Test output.name is schema.table", {
+    .output.name <- 'test_schema.resultGPapply'
+
+    # case sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM \"test_schema\".\"resultGPapply\" WHERE \"Length\" IS NOT NULL;"),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+
+    # case non-sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name,
+                " WHERE Length IS NOT NULL;", sep = ""), verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+
+})
+
+test_that("MT-Test output.name is invalid name", {
+    # TODO: this invalid parameter should throw an exception
+    .output.names <- list('"ab"', '"b.c"', 'public.ab.cd')
+    for(name in .output.names) {
+        tryCatch({
+            db.gpapply(dat.test, output.name = name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+            stop("can't be here")
+        }, error = function(e) {
+            expect_match(as.character(e), "invalid output.name:")
+        })
+    }
+})
+
+# -------------------------------------------------------------------------
+# output.signature
+# -------------------------------------------------------------------------
+test_that("MT-Test output.signature", {
+    .output.name <- 'aBc'
+    # 0. output.signature is a list, skip.
+    # 1. output.signature is NULL
+    tryCatch({
+        res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
+                    output.signature = NULL)
+        stop("shouldn't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "NULL signature, not impl")
+    })
+
+    # 2. output.signature is a function
+    f.sig <- function() return(.signature)
+    res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
+                    output.signature = f.sig, clear.existing = TRUE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name,
+                " WHERE Length IS NOT NULL;", sep = ""), verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+
+    # 3. data type is not supported
+    tryCatch({
+        f.sig <- function()
+            return(list(id = 'int', sex = 'text', length = 'invalidtype', height = 'float', shell = 'float'))
+        res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
+                    output.signature = f.sig, clear.existing = TRUE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), 'ERROR:  type "invalidtype" does not exist')
+    })
+    # 4. output.signature is any other invalid value
+    tryCatch({
+        res <- db.gpapply(dat.test, output.name = .output.name, FUN = fn.inc,
+                    output.signature = list(), clear.existing = TRUE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), 'ERROR:  ')
+    })
+})
+
+test_that("MT-Test Function applyed to data", {
+    # 0. FUN is NULL, or FUN is a simple function, skip
+    # 1. FUN is a non-function
+    tryCatch({
+        res <- db.gpapply(dat.test, output.name = NULL, output.signature = .signature,
+                        FUN = 'bad_function')
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "FUN must be a function")
+    })
+    # 2. FUN is an anonymous function
+    .output.name <- 'test_FUNC'
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = function(x) x[, c(1, 2, 3, 5, 9)], output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Length IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    # 3. FUN references outer environment
+    tryCatch({
+        db.gpapply(dat.test, output.name = .output.name,
+                    FUN = function(x) return(fn.inc(x)), output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+        stop("cann't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "ERROR:  R interpreter expression evaluation error")
+    })
+})
+
+test_that("MT-Test clear.existing", {
+    .output.name <- 'tab_existing'
+    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = .verbose)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname ='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 0, TRUE)
+
+    #0 clear.existing is TRUE, when the table doesn't exist (OK)
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
+    #1 clear.existing is TRUE, when the table exists        (OK)
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
+
+    #2 clear.existing is FALSE, when the table doesn't exist(OK)
+    # clear existing table
+    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = .verbose)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 0, TRUE)
+
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = FALSE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
+
+    #3 clear.existing is FALSE, when the table exists       (ERROR)
+    tryCatch({
+        db.gpapply(dat.test, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = FALSE, case.sensitive = FALSE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "the output table exists, but clear flag is not")
+    })
+})
+
+# -----------------------------------------------------
+# Skip case.sensitive, since it is fully tested
+# -----------------------------------------------------
+
+test_that("MT-Test distributedOn", {
+    .output.name <- 'testDistribute'
+    # randomly
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = 'randomly',
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Length IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    # replicated
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = 'replicated',
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Length IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    # columns
+    .case.sensitive <- TRUE
+    .sql <- "SELECT attname FROM pg_class, gp_distribution_policy gp, pg_attribute pa"
+    .sql <- paste(.sql, " WHERE pg_class.oid=gp.localoid and pg_class.relname = '", sep = "")
+    .sql <- paste(.sql, ifelse(.case.sensitive, .output.name, tolower(.output.name)),
+            "' and pa.attrelid=pg_class.oid and pa.attnum=ANY(gp.distkey);", sep = "")
+    res <- db.gpapply(dat.test, output.name = .output.name, output.distributeOn = as.list(names(.signature)[c(1:3)]),
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = .case.sensitive, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(.sql, verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), 3)
+})
+
+test_that("MT-Test additional junk parameters", {
+    .output.name <- 'testJunkParameter'
+    .func <- function(x, junk1, junk2, junk3) {
+        x$length <- x$length + 1
+        x$height <- x$height - 1
+        return (x[, c(1, 2, 3, 5, 9)])
+    }
+    # case sensitive
+    res <- db.gpapply(dat.test, output.name = .output.name,
+                    FUN = .func, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE,
+                    language = .language, junk1 = 12, junk2 = "Hello",
+                    junk3 = list(id = 1, name = "world"))
+    expect_equal(res, NULL)
+    res <- db.q(paste('SELECT 1 FROM "', .output.name,
+                '" WHERE "Length" IS NOT NULL;', sep = ''),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+
+})
+# --------------------------------------------------------
+# consistency of database objects
+# --------------------------------------------------------
+# the whole/most steps are
+# Create Type => Create Function => Drop existing Table
+#   => Create Table => Drop Type & Function
+#
+# When the function gpapply/gptapply returns success or with error,
+# we should Run `DROP TYPE IF EXISTS "<GPTYPE>" CASCADE;`
+# The created function is always dropped as a dependency of gptype_xxx.
+test_that("MT-Test consistency of database objects", {
+    q.type <- "SELECT count(1) FROM pg_type WHERE typname like 'gptype_%';"
+    q.func <- "SELECT count(1) FROM pg_proc WHERE proname like 'gprfunc_%';"
+
+    q.type_func <- function() {
+        res <- db.q(q.type, verbose = .verbose)
+        expect_equal(is.data.frame(res), TRUE)
+        n.type <- res[1, 1]
+        res <- db.q(q.func, verbose = .verbose)
+        expect_equal(is.data.frame(res), TRUE)
+        n.func <- res[1, 1]
+        return (list(type = n.type, func = n.func))
+    }
+    res <- q.type_func()
+    old.type <- res$type
+    old.func <- res$func
+
+    tryCatch({
+    .output.name <- 'testConsistency'
+    .func <- function(x) stop("internal error by myself")
+    db.gpapply(dat.test, output.name = .output.name,
+                    FUN = .func, output.signature = .signature,
+                    clear.existing = TRUE, language = .language)
+    stop("can't be here")
+    }, error = function(e) {
+    }, finally = {
+        res <- q.type_func()
+        expect_equal(old.type, res$type)
+        expect_equal(old.func, res$func)
+    })
+
+})
 
 
-
-db.disconnect(cid, verbose = FALSE)
+db.disconnect(cid, verbose = .verbose)

--- a/tests/testthat/test-gptapply.R
+++ b/tests/testthat/test-gptapply.R
@@ -1,0 +1,666 @@
+context("Test matrix of gptapply")
+
+## ----------------------------------------------------------------------
+## Test preparations
+
+# Need valid 'pivotalr_port' and 'pivotalr_dbname' values
+env <- new.env(parent = globalenv())
+#.dbname = get('pivotalr_dbname', envir=env)
+#.port = get('pivotalr_port', envir=env)
+.verbose <- FALSE
+
+.host <- '172.17.0.1'
+.host <- 'localhost'
+.dbname <- "d_tapply"
+.port <- 15432
+.language <- 'plr'
+## connection ID
+cid <- db.connect(host = .host, port = .port, dbname = .dbname, verbose = .verbose)
+.nrow.test <- 10
+
+dat <- abalone[c(1:.nrow.test), ]
+
+tname.1.col <- 'one_Col_Table'
+tname.mul.col <- 'mul_Col_Table'
+db.q('DROP SCHEMA IF EXISTS test_Schema CASCADE;', verbose = .verbose)
+db.q('DROP SCHEMA IF EXISTS "test_Schema" CASCADE;', verbose = .verbose)
+db.q(paste('DROP TABLE IF EXISTS "', tname.1.col, '";', sep = ''), verbose = .verbose)
+db.q(paste('DROP TABLE IF EXISTS "', tname.mul.col, '";', sep = ''), verbose = .verbose)
+
+# prepare test table
+.dat.1 <- as.data.frame(dat$rings)
+names(.dat.1) <- c('Rings')
+dat.1 <- as.db.data.frame(.dat.1, table.name = tname.1.col, verbose = .verbose)
+dat.mul <- as.db.data.frame(dat, table.name = tname.mul.col, verbose = .verbose)
+
+# ---------------------------------------------------------------
+# prepare data
+# ---------------------------------------------------------------
+test_that("Test prepare", {
+    testthat::skip_on_cran()
+    expect_equal(is.db.data.frame(dat.1), TRUE)
+    expect_equal(is.db.data.frame(dat.mul), TRUE)
+    expect_equal(nrow(dat.1), .nrow.test)
+    expect_equal(ncol(dat.1), 1)
+    expect_equal(nrow(dat.mul), .nrow.test)
+    expect_equal(ncol(dat.mul), ncol(dat))
+
+    expect_equal(db.existsObject(tname.1.col, conn.id = cid), TRUE)
+    expect_equal(db.existsObject(tname.mul.col, conn.id = cid), TRUE)
+
+    res <- db.q("CREATE SCHEMA test_Schema", verbose = .verbose)
+    expect_equal(res, NULL)
+    res <- db.q("SELECT nspname FROM pg_namespace WHERE nspname = 'test_schema';",
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), 1)
+})
+
+# test table has only one column
+dat.test <- dat.1
+.signature <- list("Rings" = "int")
+.index <- "Rings"
+fn.inc <- function(x)
+{
+    return (x[1] + 1)
+}
+# -----------------------------------------------------------
+# ONE COLUMN TABLE
+# -----------------------------------------------------------
+# test_that("Test gpt", {
+#     .output.name <- 'resultGPTapply'
+#     test_that::skip_on_cran()
+#     res <- db.gptapply(dat, INDEX = 'sex', FUN = fn, output.name = .output.name,
+# 		output.signature = .signature, clear.existing = TRUE,
+# 		case.sensitive = TRUE, language = .language)
+# })
+test_that("Test output.name is NULL", {
+    .output.name <- NULL
+
+    # case sensitive
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE, language = .language)
+    res2 <- db.q(paste("SELECT count(1) FROM \"", tname.1.col, "\" GROUP BY \"", .index, "\";", sep = ""))
+    expect_equal(is.data.frame(res) && is.data.frame(res2), TRUE)
+    expect_equal(nrow(res), nrow(res2))
+    expect_equal(ncol(res), ncol(dat.test))
+
+    # case non-sensitive
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(res2))
+    expect_equal(ncol(res), ncol(res2))
+
+    # clear.existing can be FALSE, or any other values, since output.name is NULL
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = FALSE, case.sensitive = TRUE, language = .language)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(res2))
+    expect_equal(ncol(res), ncol(res2))
+})
+
+# output.name is not NULL, and it is a single table name
+test_that("Test output.name is a table name", {
+    .output.name <- 'result_GPTapply'
+
+    # case sensitive
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM \"", .output.name, "\"",
+                " WHERE \"Rings\" IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    res2 <- db.q(paste("SELECT count(1) FROM \"", tname.1.col, "\" GROUP BY \"", .index, "\";", sep = ""))
+    expect_equal(is.data.frame(res) && is.data.frame(res2), TRUE)
+    expect_equal(nrow(res), nrow(res2))
+
+    # case non-sensitive
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE,
+                    language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name,
+                " WHERE Rings IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(res2))
+})
+
+# output.name is not NULL, and it is a single table name
+test_that("Test output.name is schema.table", {
+    .output.name <- 'test_schema.resultGPTapply'
+
+    # case sensitive
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM \"test_schema\".\"resultGPTapply\" WHERE \"Rings\" IS NOT NULL;"),
+                verbose = .verbose)
+    res2 <- db.q(paste("SELECT count(1) FROM \"", tname.1.col, "\" GROUP BY \"", .index, "\";", sep = ""))
+    expect_equal(is.data.frame(res) && is.data.frame(res2), TRUE)
+    expect_equal(nrow(res), nrow(res2))
+
+    # case non-sensitive
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name,
+                " WHERE Rings IS NOT NULL;", sep = ""), verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(res2))
+})
+
+test_that("Test output.name is invalid name", {
+    # TODO: this invalid parameter should throw an exception
+    .output.names <- list('"ab"', '"b.c"', 'public.ab.cd')
+    for(name in .output.names) {
+        tryCatch({
+            db.gptapply(dat.test, INDEX = .index, output.name = name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+            stop("can't be here")
+        }, error = function(e) {
+            expect_match(as.character(e), "invalid output.name:")
+        })
+    }
+})
+
+# -------------------------------------------------------------------------
+# index
+# -------------------------------------------------------------------------
+test_that("Test INDEX is invalid", {
+    # index exceed number of columns
+    .test.index <- 3
+    .output.name <- 'result_gptapply_temp'
+    tryCatch({
+        db.gptapply(dat.test, INDEX = .test.index, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "INDEX value cannot exceed")
+    })
+
+    # INDEX column name does not exist in col.name
+    .test.index <- "invalidIndex"
+    tryCatch({
+        db.gptapply(dat.test, INDEX = .test.index, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "invalid INDEX value:")
+    })
+})
+
+# -------------------------------------------------------------------------
+# output.signature
+# -------------------------------------------------------------------------
+test_that("Test output.signature", {
+    .output.name <- 'aBc'
+    # 0. output.signature is a list, skip.
+    # 1. output.signature is NULL
+    tryCatch({
+        res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, FUN = fn.inc,
+                    output.signature = NULL)
+        stop("shouldn't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "NULL signature, not impl")
+    })
+
+    # 2. output.signature is a function
+    f.sig <- function() return(.signature)
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, FUN = fn.inc,
+                    output.signature = f.sig, clear.existing = TRUE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name,
+                " WHERE Rings IS NOT NULL;", sep = ""), verbose = .verbose)
+    res2 <- db.q(paste("SELECT count(1) FROM \"", tname.1.col, "\" GROUP BY \"", .index, "\";", sep = ""))
+    expect_equal(is.data.frame(res) && is.data.frame(res2), TRUE)
+    expect_equal(nrow(res), nrow(res2))
+
+    # 3. data type is not supported
+    tryCatch({
+        f.sig <- function() return(list("Rings" = "invalidType"))
+        res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, FUN = fn.inc,
+                    output.signature = f.sig, clear.existing = TRUE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), 'ERROR:  type "invalidtype" does not exist')
+    })
+    # 4. output.signature is any other invalid value
+    tryCatch({
+        res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, FUN = fn.inc,
+                    output.signature = list(), clear.existing = TRUE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), 'ERROR:  ')
+    })
+})
+
+test_that("Test Function applyed to data", {
+    # 0. FUN is NULL, or FUN is a simple function, skip
+    # 1. FUN is a non-function
+    tryCatch({
+        res <- db.gptapply(dat.test, INDEX = .index, output.name = NULL, output.signature = .signature,
+                        FUN = 'bad_function')
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "FUN must be a function")
+    })
+    # 2. FUN is an anonymous function
+    .output.name <- 'test_FUNC'
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = function(x) x[1] + 1, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Rings IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    res2 <- db.q(paste("SELECT count(1) FROM \"", tname.1.col, "\" GROUP BY \"", .index, "\";", sep = ""))
+    expect_equal(is.data.frame(res) && is.data.frame(res2), TRUE)
+    expect_equal(nrow(res), nrow(res2))
+    # 3. FUN references outer environment
+    tryCatch({
+        db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = function(x) return(fn.inc(x)), output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+        stop("cann't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "ERROR:  R interpreter expression evaluation error")
+    })
+})
+
+test_that("Test clear.existing", {
+    .output.name <- 'tab_existing'
+    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = .verbose)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname ='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 0, TRUE)
+
+    #0 clear.existing is TRUE, when the table doesn't exist (OK)
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
+    #1 clear.existing is TRUE, when the table exists        (OK)
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
+
+    #2 clear.existing is FALSE, when the table doesn't exist(OK)
+    # clear existing table
+    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = .verbose)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 0, TRUE)
+
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = FALSE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
+
+    #3 clear.existing is FALSE, when the table exists       (ERROR)
+    tryCatch({
+        db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = FALSE, case.sensitive = FALSE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "the output table exists, but clear flag is not")
+    })
+})
+
+
+# -----------------------------------------------------
+# Skip case.sensitive, since it is fully tested
+# -----------------------------------------------------
+
+test_that("Test distributedOn", {
+    .output.name <- 'testDistribute'
+    # randomly
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, output.distributeOn = 'randomly',
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Rings IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    res2 <- db.q(paste("SELECT count(1) FROM \"", tname.1.col, "\" GROUP BY \"", .index, "\";", sep = ""))
+    expect_equal(is.data.frame(res) && is.data.frame(res2), TRUE)
+    expect_equal(nrow(res), nrow(res2))
+    # replicated
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, output.distributeOn = 'replicated',
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Rings IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(res2))
+    # columns
+    .sql <- "SELECT attname FROM pg_class, gp_distribution_policy gp, pg_attribute pa"
+    .sql <- paste(.sql, " WHERE pg_class.oid=gp.localoid and pg_class.relname = '", sep = "")
+    .sql <- paste(.sql, tolower(.output.name),
+            "' and pa.attrelid=pg_class.oid and pa.attnum=ANY(gp.distkey);", sep = "")
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, output.distributeOn = list(names(.signature)[1]),
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(.sql, verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), 1)
+})
+
+test_that("Test language", {
+    # the language should be 'plr' or 'plcontainer'
+    skip("skip.language")
+})
+
+test_that("Test additional junk parameters", {
+    .output.name <- 'testJunkParameter'
+    .func <- function(x, junk1, junk2, junk3) {
+        return (x[1] + 1)
+    }
+    # case sensitive
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = .func, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE,
+                    language = .language, junk1 = 12, junk2 = "Hello",
+                    junk3 = list(id = 1, name = "world"))
+    expect_equal(res, NULL)
+    res <- db.q(paste('SELECT 1 FROM "', .output.name,
+                '" WHERE "Rings" IS NOT NULL;', sep = ''),
+                verbose = .verbose)
+    res2 <- db.q(paste("SELECT count(1) FROM \"", tname.1.col, "\" GROUP BY \"", .index, "\";", sep = ""))
+    expect_equal(is.data.frame(res) && is.data.frame(res2), TRUE)
+    expect_equal(nrow(res), nrow(res2))
+})
+
+
+# --------------------------------------------------------------------------
+# MULTIPLE COLUMNS TABLE
+# --------------------------------------------------------------------------
+dat.test <- dat.mul
+# columns as the output table
+.col.chooser <- c(1,2,3,10)
+#.signature <- list(id = 'int', 'Sex' = 'text', 'Rings' = 'int', height = 'float', shell = 'float')
+.signature <- list(id = 'int', sex = 'text', 'Length' = 'float', 'Rings' = 'int')
+
+fn.inc <- function(x)
+{
+    # x$length <- x$length + 1
+    # x$height <- x$height - 1
+    x$id <- x$rings
+    x$length <- mean(x$length)
+    return (x[, c(1,2,3,10)])
+}
+
+# output.name is not NULL, and it is a single table name
+test_that("MT-Test output.name is a table name", {
+    .output.name <- NULL
+
+    # case sensitive
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE, language = .language)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), .nrow.test)
+    expect_equal(ncol(res), length(.signature))
+
+    # case non-sensitive
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE,
+                    language = .language)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), .nrow.test)
+    expect_equal(ncol(res), length(.signature))
+})
+
+# output.name is not NULL, and it is a single table name
+test_that("MT-Test output.name is a table name", {
+    .output.name <- 'result_GPTapply'
+
+    # case sensitive
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM \"", .output.name,
+                "\" WHERE \"Rings\" IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+
+    # case non-sensitive
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE,
+                    language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name,
+                " WHERE Rings IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+})
+
+test_that("MT-Test output.name is invalid name", {
+    # TODO: this invalid parameter should throw an exception
+    .output.names <- list('"ab"', '"b.c"', 'public.ab.cd')
+    for(name in .output.names) {
+        tryCatch({
+            db.gptapply(dat.test, INDEX = .index, output.name = name,
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+            stop("can't be here")
+        }, error = function(e) {
+            expect_match(as.character(e), "invalid output.name:")
+        })
+    }
+})
+
+
+# -------------------------------------------------------------------------
+# output.signature
+# -------------------------------------------------------------------------
+test_that("MT-Test output.signature", {
+    .output.name <- 'aBc'
+    # 0. output.signature is a list, skip.
+    # 1. output.signature is NULL
+    tryCatch({
+        res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, FUN = fn.inc,
+                    output.signature = NULL)
+        stop("shouldn't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "NULL signature, not impl")
+    })
+
+    # 2. output.signature is a function
+    f.sig <- function() return(.signature)
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, FUN = fn.inc,
+                    output.signature = f.sig, clear.existing = TRUE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name,
+                " WHERE Rings IS NOT NULL;", sep = ""), verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+
+    # 3. data type is not supported
+    tryCatch({
+        f.sig <- function()
+            return(list(id = 'int', sex = 'text', length = 'invalidtype', height = 'float', shell = 'float'))
+        res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, FUN = fn.inc,
+                    output.signature = f.sig, clear.existing = TRUE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), 'ERROR:  type "invalidtype" does not exist')
+    })
+    # 4. output.signature is any other invalid value
+    tryCatch({
+        res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, FUN = fn.inc,
+                    output.signature = list(), clear.existing = TRUE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), 'ERROR:  ')
+    })
+})
+
+test_that("MT-Test Function applyed to data", {
+    # 0. FUN is NULL, or FUN is a simple function, skip
+    # 1. FUN is a non-function
+    tryCatch({
+        res <- db.gptapply(dat.test, INDEX = .index, output.name = NULL, output.signature = .signature,
+                        FUN = 'bad_function')
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "FUN must be a function")
+    })
+    # 2. FUN is an anonymous function
+    .output.name <- 'test_FUNC'
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = function(x) x[, c(1, 2, 3, 10)], output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Rings IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    # 3. FUN references outer environment
+    tryCatch({
+        db.gpapply(dat.test, output.name = .output.name,
+                    FUN = function(x) return(fn.inc(x)), output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+        stop("cann't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "ERROR:  R interpreter expression evaluation error")
+    })
+})
+
+test_that("MT-Test clear.existing", {
+    .output.name <- 'tab_existing'
+    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = .verbose)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname ='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 0, TRUE)
+
+    #0 clear.existing is TRUE, when the table doesn't exist (OK)
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
+    #1 clear.existing is TRUE, when the table exists        (OK)
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
+
+    #2 clear.existing is FALSE, when the table doesn't exist(OK)
+    # clear existing table
+    db.q(paste("DROP TABLE IF EXISTS ", .output.name, ";", sep = ""), verbose = .verbose)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 0, TRUE)
+
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = FALSE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM pg_class WHERE relname='", .output.name, "';", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
+
+    #3 clear.existing is FALSE, when the table exists       (ERROR)
+    tryCatch({
+        db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                FUN = fn.inc, output.signature = .signature,
+                clear.existing = FALSE, case.sensitive = FALSE, language = .language)
+        stop("can't be here")
+    }, error = function(e) {
+        expect_match(as.character(e), "the output table exists, but clear flag is not")
+    })
+})
+
+# -----------------------------------------------------
+# Skip case.sensitive, since it is fully tested
+# -----------------------------------------------------
+
+test_that("MT-Test distributedOn", {
+    .output.name <- 'testDistribute'
+    # randomly
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, output.distributeOn = 'randomly',
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Rings IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    # replicated
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, output.distributeOn = 'replicated',
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = FALSE, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(paste("SELECT 1 FROM ", .output.name, " WHERE Rings IS NOT NULL;", sep = ""),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+    # columns
+    .case.sensitive <- TRUE
+    .sql <- "SELECT attname FROM pg_class, gp_distribution_policy gp, pg_attribute pa"
+    .sql <- paste(.sql, " WHERE pg_class.oid=gp.localoid and pg_class.relname = '", sep = "")
+    .sql <- paste(.sql, ifelse(.case.sensitive, .output.name, tolower(.output.name)),
+            "' and pa.attrelid=pg_class.oid and pa.attnum=ANY(gp.distkey);", sep = "")
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name, output.distributeOn = as.list(names(.signature)[c(1:3)]),
+                    FUN = fn.inc, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = .case.sensitive, language = .language)
+    expect_equal(res, NULL)
+    res <- db.q(.sql, verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), 3)
+})
+
+test_that("MT-Test additional junk parameters", {
+    .output.name <- 'testJunkParameter'
+    .func <- function(x, junk1, junk2, junk3) {
+        x$length <- x$length + 1
+        x$height <- x$height - 1
+        return (x[, c(1, 2, 3, 10)])
+    }
+    # case sensitive
+    res <- db.gptapply(dat.test, INDEX = .index, output.name = .output.name,
+                    FUN = .func, output.signature = .signature,
+                    clear.existing = TRUE, case.sensitive = TRUE,
+                    language = .language, junk1 = 12, junk2 = "Hello",
+                    junk3 = list(id = 1, name = "world"))
+    expect_equal(res, NULL)
+    res <- db.q(paste('SELECT 1 FROM "', .output.name,
+                '" WHERE "Rings" IS NOT NULL;', sep = ''),
+                verbose = .verbose)
+    expect_equal(is.data.frame(res), TRUE)
+    expect_equal(nrow(res), nrow(dat.test))
+})
+db.disconnect(cid)


### PR DESCRIPTION
1. Improve index handling for gptapply.
2. Add gptapply test cases.
3. Add gpapply multiple column test cases.
4. Refactor code for gptapply.
5. Add error handling for gptapply.

Co-authored-by: Hao Wu <hawu@pivotal.io>
Co-authored-by: Xinyue Ge <xge@pivotal.io>