### PR TITLE
Add pipeline of GreenplumR for plr

### DIFF
--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -1,0 +1,79 @@
+groups:
+- name: plr
+  jobs:
+  - test_plr_centos7
+
+resource_types:
+- name: gcs
+  type: docker-image
+  source:
+    repository: frodenas/gcs-resource
+
+resources:
+
+# Image Resources
+- name: centos-gpdb-dev-7
+  type: docker-image
+  source:
+    repository: pivotaldata/centos-gpdb-dev
+    tag: '7-gcc6.2-llvm3.7'
+
+# - name: ubuntu18-image-test
+#   type: docker-image
+#   source:
+#     repository: pivotaldata/gpdb6-ubuntu18.04-test
+#     tag: latest
+
+# Github Source Codes
+
+- name: gpdb_src
+  type: git
+  source:
+    branch: {{gpdb-git-branch}}
+    uri: {{gpdb-git-remote}}
+
+- name: GreenplumR_src
+  type: git
+  source:
+    branch: master
+    uri: https://github.com/greenplum-db/GreenplumR.git
+    
+
+- name: bin_gpdb_centos7
+  type: gcs
+  source:
+    bucket: ((gcs-bucket-intermediates))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    versioned_file: gpdb_master/bin_gpdb_centos7/bin_gpdb.tar.gz
+
+# - name: bin_gpdb_ubuntu18
+#   type: gcs
+#   source:
+#     bucket: {{gcs-bucket-intermediates}}
+#     json_key: {{concourse-gcs-resources-service-account-key}}
+#     versioned_file: ((gcs_gpdb_binary_folder))/bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz
+
+- name: bin_plr_centos7
+  type: gcs
+  source:
+    bucket: ((gcs-bucket-intermediates))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: plr/released/gpdb6/plr-(*)-rhel7-x86_64.gppkg
+
+
+jobs:
+
+- name: test_plr_centos7
+  plan:
+  - aggregate:
+    - get: gpdb_src
+    - get: GreenplumR_src
+    - get: bin_gpdb
+      resource: bin_gpdb_centos7
+    - get: bin_plr
+      resource: bin_plr_centos7
+    - get: centos-gpdb-dev-7
+  - task: test_greenplumr_plr_centos7
+    file: GreenplumR_src/concourse/tasks/test_plr.yml
+    image: centos-gpdb-dev-7
+

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -36,8 +36,8 @@ resources:
 - name: GreenplumR_src
   type: git
   source:
-    branch: pipeline
-    uri: https://github.com/XinyueGe/GreenplumR.git
+    branch: master
+    uri: https://github.com/greenplum-db/GreenplumR.git
 
 - name: bin_gpdb_centos7
   type: gcs

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -1,7 +1,10 @@
 groups:
 - name: plr
   jobs:
-  - test_plr_centos7
+  - test_plr_light_centos7
+  - test_plr_full_centos7
+  - test_plr_light_ubuntu18
+  - test_plr_full_ubuntu18
 
 resource_types:
 - name: gcs
@@ -10,7 +13,6 @@ resource_types:
     repository: frodenas/gcs-resource
 
 resources:
-
 # Image Resources
 - name: centos-gpdb-dev-7
   type: docker-image
@@ -18,52 +20,71 @@ resources:
     repository: pivotaldata/centos-gpdb-dev
     tag: '7-gcc6.2-llvm3.7'
 
-# - name: ubuntu18-image-test
-#   type: docker-image
-#   source:
-#     repository: pivotaldata/gpdb6-ubuntu18.04-test
-#     tag: latest
+- name: ubuntu18-image-test
+  type: docker-image
+  source:
+    repository: pivotaldata/gpdb6-ubuntu18.04-test
+    tag: latest
 
 # Github Source Codes
-
 - name: gpdb_src
   type: git
   source:
-    branch: {{gpdb-git-branch}}
-    uri: {{gpdb-git-remote}}
+    branch: 6X_STABLE
+    uri: https://github.com/greenplum-db/gpdb.git
 
 - name: GreenplumR_src
   type: git
   source:
-    branch: master
-    uri: https://github.com/greenplum-db/GreenplumR.git
-    
+    branch: pipeline
+    uri: https://github.com/XinyueGe/GreenplumR.git
 
 - name: bin_gpdb_centos7
   type: gcs
   source:
     bucket: ((gcs-bucket-intermediates))
     json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: gpdb_master/bin_gpdb_centos7/bin_gpdb.tar.gz
+    versioned_file: 6X_STABLE/bin_gpdb_centos7/bin_gpdb.tar.gz
 
-# - name: bin_gpdb_ubuntu18
-#   type: gcs
-#   source:
-#     bucket: {{gcs-bucket-intermediates}}
-#     json_key: {{concourse-gcs-resources-service-account-key}}
-#     versioned_file: ((gcs_gpdb_binary_folder))/bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz
-
-- name: bin_plr_centos7
+- name: bin_gpdb_ubuntu18
   type: gcs
   source:
     bucket: ((gcs-bucket-intermediates))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: plr/released/gpdb6/plr-(*)-rhel7-x86_64.gppkg
+    versioned_file: 6X_STABLE/bin_gpdb_ubuntu18.04/bin_gpdb.tar.gz
 
+- name: bin_plr_centos7
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: plr/released/gpdb6/plr-(.*)-rhel7_x86_64.gppkg
+
+- name: bin_plr_ubuntu18
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: plr/released/gpdb6/plr-(.*)-ubuntu18.04_x86_64.gppkg
 
 jobs:
+- name: test_plr_light_centos7
+  plan:
+  - aggregate:
+    - get: gpdb_src
+    - get: GreenplumR_src
+      trigger: true
+    - get: bin_gpdb
+      resource: bin_gpdb_centos7
+    - get: bin_plr
+      resource: bin_plr_centos7
+    - get: centos-gpdb-dev-7
+  - task: test_greenplumr_plr_centos7
+    file: GreenplumR_src/concourse/tasks/test_plr.yml
+    image: centos-gpdb-dev-7
+    params:
 
-- name: test_plr_centos7
+- name: test_plr_full_centos7
   plan:
   - aggregate:
     - get: gpdb_src
@@ -76,4 +97,38 @@ jobs:
   - task: test_greenplumr_plr_centos7
     file: GreenplumR_src/concourse/tasks/test_plr.yml
     image: centos-gpdb-dev-7
+    params:
+      MODE: full
+
+- name: test_plr_light_ubuntu18
+  plan:
+  - aggregate:
+    - get: gpdb_src
+    - get: GreenplumR_src
+      trigger: true
+    - get: bin_gpdb
+      resource: bin_gpdb_ubuntu18
+    - get: bin_plr
+      resource: bin_plr_ubuntu18
+    - get: ubuntu18-image-test
+  - task: test_greenplumr_plr
+    file: GreenplumR_src/concourse/tasks/test_plr.yml
+    image: ubuntu18-image-test
+    params:
+
+- name: test_plr_full_ubuntu18
+  plan:
+  - aggregate:
+    - get: gpdb_src
+    - get: GreenplumR_src
+    - get: bin_gpdb
+      resource: bin_gpdb_ubuntu18
+    - get: bin_plr
+      resource: bin_plr_ubuntu18
+    - get: ubuntu18-image-test
+  - task: test_greenplumr_plr
+    file: GreenplumR_src/concourse/tasks/test_plr.yml
+    image: ubuntu18-image-test
+    params:
+      MODE: full
 

--- a/concourse/scripts/install_r_package.R
+++ b/concourse/scripts/install_r_package.R
@@ -1,0 +1,9 @@
+#!/usr/bin/env Rscript
+# called with package name as arg[1]
+# and destination as arg[2]
+args = commandArgs(trailingOnly=TRUE)
+cran = getOption("repos") 
+cran["CRAN"] = "https://cran.mtu.edu/"
+options(repos = cran)
+rm (cran)
+install.packages(args[1])

--- a/concourse/scripts/test_plr.sh
+++ b/concourse/scripts/test_plr.sh
@@ -1,0 +1,104 @@
+#!/bin/bash -l
+
+set -exo pipefail
+OLDPATH=${PATH}
+echo "OLDPATH = ${OLDPATH}"
+CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TOP_DIR=${CWDIR}/../../../
+GPDB_CONCOURSE_DIR=${TOP_DIR}/gpdb_src/concourse/scripts
+
+source "${GPDB_CONCOURSE_DIR}/common.bash"
+function test() {
+  cat > /home/gpadmin/test.sh <<-EOF
+#!/bin/bash -l
+set -exo pipefail
+export GPRLANGUAGE=plr
+pushd ${TOP_DIR}/GreenplumR_src
+  source /usr/local/greenplum-db-devel/greenplum_path.sh
+  source ${TOP_DIR}/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+  gppkg -i ${TOP_DIR}/bin_plr/plr-*.gppkg
+  sleep 1
+  gpstop -arf
+  createdb d_apply
+  createdb d_tapply
+  # start test
+  sleep 3
+  export PATH=${OLDPATH}
+  export R_HOME=`R RHOME`
+  unset LD_LIBRARY_PATH
+  unset R_LIBS_USER
+  R CMD check .
+popd
+EOF
+
+  chown -R gpadmin:gpadmin $(pwd)
+  chown gpadmin:gpadmin /home/gpadmin/test.sh
+  chmod a+x /home/gpadmin/test.sh
+  su gpadmin -c "/bin/bash /home/gpadmin/test.sh"
+}
+
+function determine_os() {
+    if [ -f /etc/redhat-release ] ; then
+      echo "centos"
+      return
+    fi
+    if grep -q ID=ubuntu /etc/os-release ; then
+      echo "ubuntu"
+      return
+    fi
+    echo "Could not determine operating system type" >/dev/stderr
+    exit 1
+}
+
+function setup_gpadmin_user() {
+    ${GPDB_CONCOURSE_DIR}/setup_gpadmin_user.bash
+}
+
+function prepare_lib() {
+    ${CWDIR}/install_r_package.R devtools
+    ${CWDIR}/install_r_package.R testthat
+    ${CWDIR}/install_r_package.R DBI
+    ${CWDIR}/install_r_package.R RPostgreSQL
+    ${CWDIR}/install_r_package.R shiny
+    ${CWDIR}/install_r_package.R ini
+}
+
+function install_pkg() {
+  case $TEST_OS in
+  centos)
+    yum install -y epel-release
+    yum install -y R
+    ;;
+  ubuntu)
+    apt update
+    DEBIAN_FRONTEND=noninteractive apt install -y r-base pkg-config
+    #texlive-latex-base texinfo texlive-fonts-extra
+    ;;
+  *)
+    echo "unknown OSVER = $TEST_OS"
+    exit 1
+    ;;
+  esac
+}
+
+function install_plr() {
+    source /usr/local/greenplum-db-devel/greenplum_path.sh
+    source ${TOP_DIR}/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+    gppkg -i ${TOP_DIR}/bin_plr/plr-*.gppkg
+    sleep 1
+    gpstop -arf
+}
+
+function _main() {
+    TEST_OS=$(determine_os)
+    time install_pkg
+    time install_gpdb
+    time setup_gpadmin_user
+
+    time make_cluster
+    
+    time prepare_lib
+    time test
+}
+
+_main "$@"

--- a/concourse/scripts/test_plr.sh
+++ b/concourse/scripts/test_plr.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -l
-
 set -exo pipefail
+
 OLDPATH=${PATH}
 echo "OLDPATH = ${OLDPATH}"
 CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/concourse/scripts/test_plr.sh
+++ b/concourse/scripts/test_plr.sh
@@ -6,35 +6,56 @@ echo "OLDPATH = ${OLDPATH}"
 CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TOP_DIR=${CWDIR}/../../../
 GPDB_CONCOURSE_DIR=${TOP_DIR}/gpdb_src/concourse/scripts
+# light or full
+MODE=${MODE:=light}
 
 source "${GPDB_CONCOURSE_DIR}/common.bash"
-function test() {
-  cat > /home/gpadmin/test.sh <<-EOF
+
+function test_run() {
+  cat > /home/gpadmin/test_prepare.sh <<-EOF
+#!/bin/bash -l
+# install plr and restart gpdb
+# then prepare databases needed by test
+set -exo pipefail
+source /usr/local/greenplum-db-devel/greenplum_path.sh
+source ${TOP_DIR}/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+gppkg -i ${TOP_DIR}/bin_plr/plr-*.gppkg
+sleep 1
+source /usr/local/greenplum-db-devel/greenplum_path.sh
+source ${TOP_DIR}/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+gpstop -arf
+createdb rtest
+createdb d_apply
+createdb d_tapply
+EOF
+  cat > /home/gpadmin/test_run.sh <<-EOF
 #!/bin/bash -l
 set -exo pipefail
 export GPRLANGUAGE=plr
 pushd ${TOP_DIR}/GreenplumR_src
-  source /usr/local/greenplum-db-devel/greenplum_path.sh
-  source ${TOP_DIR}/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
-  gppkg -i ${TOP_DIR}/bin_plr/plr-*.gppkg
-  sleep 1
-  gpstop -arf
-  createdb d_apply
-  createdb d_tapply
-  # start test
+  # clear environment introduced by gpdb that may affect R
   sleep 3
   export PATH=${OLDPATH}
-  export R_HOME=`R RHOME`
-  unset LD_LIBRARY_PATH
+  unset R_HOME
   unset R_LIBS_USER
-  R CMD check .
+  unset LD_LIBRARY_PATH
+  if [ "$MODE" == "light" ] ; then
+    echo "library(testthat)" > test_script.R
+    echo "testthat::test_dir('tests', reporter = 'stop', stop_on_failure = TRUE)" >> test_script.R
+    R --no-save < test_script.R
+  else
+    R CMD check .
+  fi
 popd
 EOF
 
   chown -R gpadmin:gpadmin $(pwd)
-  chown gpadmin:gpadmin /home/gpadmin/test.sh
-  chmod a+x /home/gpadmin/test.sh
-  su gpadmin -c "/bin/bash /home/gpadmin/test.sh"
+  pushd /home/gpadmin
+    chown gpadmin:gpadmin test_prepare.sh test_run.sh
+    chmod a+x test_prepare.sh test_run.sh
+  popd
+  su gpadmin -c "/bin/bash /home/gpadmin/test_prepare.sh"
+  su gpadmin -c "/bin/bash /home/gpadmin/test_run.sh"
 }
 
 function determine_os() {
@@ -54,51 +75,69 @@ function setup_gpadmin_user() {
     ${GPDB_CONCOURSE_DIR}/setup_gpadmin_user.bash
 }
 
-function prepare_lib() {
-    ${CWDIR}/install_r_package.R devtools
+function install_libraries() {
+    # install system libraries
+    case $TEST_OS in
+    centos)
+      yum install -y epel-release
+      # postgresql-devel is needed by RPostgreSQL
+      yum install -y R postgresql-devel
+      ;;
+    ubuntu)
+      apt update
+      DEBIAN_FRONTEND=noninteractive apt install -y r-base libpq-dev
+      ;;
+    *)
+      echo "unknown TEST_OS = $TEST_OS"
+      exit 1
+      ;;
+    esac
+    # install r libraries
     ${CWDIR}/install_r_package.R testthat
-    ${CWDIR}/install_r_package.R DBI
     ${CWDIR}/install_r_package.R RPostgreSQL
     ${CWDIR}/install_r_package.R shiny
     ${CWDIR}/install_r_package.R ini
 }
 
-function install_pkg() {
+function install_libraries_full() {
+  install_libraries
+  # install system libraries
   case $TEST_OS in
   centos)
-    yum install -y epel-release
-    yum install -y R
+    # no more packages need to install
     ;;
   ubuntu)
-    apt update
-    DEBIAN_FRONTEND=noninteractive apt install -y r-base pkg-config
-    #texlive-latex-base texinfo texlive-fonts-extra
-    ;;
-  *)
-    echo "unknown OSVER = $TEST_OS"
-    exit 1
+    DEBIAN_FRONTEND=noninteractive apt install -y pkg-config \
+        texlive-latex-base texlive-fonts-extra
     ;;
   esac
+
+  # install additional r libraries
 }
 
-function install_plr() {
-    source /usr/local/greenplum-db-devel/greenplum_path.sh
-    source ${TOP_DIR}/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
-    gppkg -i ${TOP_DIR}/bin_plr/plr-*.gppkg
-    sleep 1
-    gpstop -arf
+function install_libraries_light() {
+    install_libraries
+    tar czf ${TOP_DIR}/GreenplumR.tar.gz ${TOP_DIR}/GreenplumR_src
+    R CMD INSTALL ${TOP_DIR}/GreenplumR.tar.gz
 }
 
+# install libraries (light/full)
+# install gpdb
+# setup gpadmin
+# make cluster
+# install plr/plcontainer
+# restart gpdb
+# clear environment introduced by gpdb
+#
+# run tests (light/full)
 function _main() {
     TEST_OS=$(determine_os)
-    time install_pkg
+    time install_libraries_${MODE}
     time install_gpdb
     time setup_gpadmin_user
-
     time make_cluster
-    
-    time prepare_lib
-    time test
+
+    time test_run
 }
 
 _main "$@"

--- a/concourse/tasks/test_plr.yml
+++ b/concourse/tasks/test_plr.yml
@@ -1,0 +1,15 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+
+inputs:
+  - name: gpdb_src
+  - name: GreenplumR_src
+  - name: bin_gpdb
+  - name: bin_plr
+
+run:
+  path: GreenplumR_src/concourse/scripts/test_plr.sh
+
+params:

--- a/concourse/tasks/test_plr.yml
+++ b/concourse/tasks/test_plr.yml
@@ -9,7 +9,10 @@ inputs:
   - name: bin_gpdb
   - name: bin_plr
 
+outputs:
+
 run:
   path: GreenplumR_src/concourse/scripts/test_plr.sh
 
 params:
+  MODE:

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -11,8 +11,15 @@ env <- new.env(parent = globalenv())
 .host <- 'localhost'
 .dbname <- "rtest"
 .port <- 15432
+.language <- tolower(Sys.getenv('GPRLANGUAGE'))
+if (.language != 'plr' && .language != 'plcontainer')
+    stop(paste0("invalid GPRLANGUAGE:", .language))
 ## connection ID
 cid <- db.connect(host = .host, port = .port, dbname = .dbname, verbose = FALSE)
+
+# drop-create extension
+db.q(paste0('DROP EXTENSION IF EXISTS ', .language, ' CASCADE;'))
+db.q(paste0('CREATE EXTENSION ', .language, ';'))
 
 ## data in the database
 dat <- as.db.data.frame(abalone, conn.id = cid, verbose = FALSE)
@@ -121,7 +128,7 @@ test_that("Test .create.r.wrapper", {
     funName <- .to.func.name(basename)
     typeName <- .to.type.name(basename)
     runtime.id <- 'plc_r_poison'
-    language <- 'plr'
+    language <- .language
     Xattr <- attributes(X)
     .sql <- .create.r.wrapper2(basename = basename, FUN = sqrtFUN,
                                 selected.type.list = .selected.type.list(Xattr),

--- a/tests/testthat/test-gptapply.R
+++ b/tests/testthat/test-gptapply.R
@@ -9,11 +9,12 @@ env <- new.env(parent = globalenv())
 #.port = get('pivotalr_port', envir=env)
 .verbose <- FALSE
 
-.host <- '172.17.0.1'
 .host <- 'localhost'
 .dbname <- "d_tapply"
 .port <- 15432
-.language <- 'plr'
+.language <- tolower(Sys.getenv('GPRLANGUAGE'))
+if (.language != 'plr' && .language != 'plcontainer')
+    stop(paste0("invalid GPRLANGUAGE:", .language))
 ## connection ID
 cid <- db.connect(host = .host, port = .port, dbname = .dbname, verbose = .verbose)
 .nrow.test <- 10
@@ -29,6 +30,9 @@ db.q(paste('DROP TABLE IF EXISTS "', tname.mul.col, '";', sep = ''), verbose = .
 db.q('CREATE SCHEMA test_Schema;', verbose = .verbose)
 db.q('CREATE SCHEMA "test_Schema";', verbose = .verbose)
 
+# drop-create extension
+db.q(paste0('DROP EXTENSION IF EXISTS ', .language, ' CASCADE;'))
+db.q(paste0('CREATE EXTENSION ', .language, ';'))
 # prepare test table
 .dat.1 <- as.data.frame(dat$rings)
 names(.dat.1) <- c('Rings')
@@ -53,6 +57,9 @@ test_that("Test prepare", {
                 verbose = .verbose)
     expect_equal(is.data.frame(res), TRUE)
     expect_equal(nrow(res), 1)
+
+    res <- db.q(paste0("SELECT 1 FROM pg_extension WHERE extname='", .language, "';"))
+    expect_equal(is.data.frame(res) && nrow(res) == 1, TRUE)
 })
 
 # test table has only one column


### PR DESCRIPTION
Add pipeline of GreenplumR, using plr as R computation

Two platforms are added, centos7 and ubuntu18.04
There are 2 test modes, light/full.
**light** mode only tests R code, not including documentation, dependency, etc.
**full** mode runs `R CMD check .` to test R code, check documentation
and dependencies etc.