### PR TITLE
Add pipeline of GreenplumR for plcontainer

### DIFF
--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -1,4 +1,13 @@
 groups:
+- name: All
+  jobs:
+  - test_plr_light_centos7
+  - test_plr_full_centos7
+  - test_plr_light_ubuntu18
+  - test_plr_full_ubuntu18
+  - test_plcontainer_centos7
+  - test_plcontainer_ubuntu18
+
 - name: plr
   jobs:
   - test_plr_light_centos7
@@ -6,11 +15,84 @@ groups:
   - test_plr_light_ubuntu18
   - test_plr_full_ubuntu18
 
+- name: plcontainer
+  jobs:
+  - test_plcontainer_centos7
+  - test_plcontainer_ubuntu18
+
+#####################################################
+#################### RESOURCES ######################
+#####################################################
+ccp_create_params_anchor: &ccp_default_params
+  action: create
+  delete_on_failure: true
+  generate_random_name: true
+  terraform_source: ccp_src/google/
+
+ccp_vars_anchor: &ccp_default_vars
+  instance_type: n1-standard-4
+  region: {{google-region}}
+  zone: {{google-zone}}
+  disk_size: 100
+
+ccp_gen_cluster_default_params_anchor: &ccp_gen_cluster_default_params
+  AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
+  AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+  AWS_DEFAULT_REGION: {{aws-region}}
+  BUCKET_PATH: clusters-google/
+  BUCKET_NAME: {{tf-bucket-name}}
+  CLOUD_PROVIDER: google
+
+ccp_destroy_anchor: &ccp_destroy
+  put: terraform
+  params:
+    action: destroy
+    env_name_file: terraform/name
+    terraform_source: ccp_src/google/
+    vars:
+      aws_instance-node-instance_type: t2.micro #t2.micro is ignored in destroy, but aws_instance-node-instance_type is required.
+      aws_ebs_volume_type: standard
+  get_params:
+    action: destroy
+
+set_failed_anchor: &set_failed
+  do:
+  - task: on_failure_set_failed
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: pivotaldata/ccp
+          tag: "7"
+      inputs:
+        - name: ccp_src
+        - name: terraform
+      run:
+        path: 'ccp_src/google/ccp_failed_test.sh'
+      params:
+        GOOGLE_CREDENTIALS: {{google-service-account-key}}
+        GOOGLE_PROJECT_ID: {{google-project-id}}
+        GOOGLE_ZONE: {{google-zone}}
+        GOOGLE_SERVICE_ACCOUNT: {{google-service-account}}
+        AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
+        AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+        AWS_DEFAULT_REGION: {{tf-machine-region}}
+        BUCKET_PATH: clusters-google/
+        BUCKET_NAME: {{tf-bucket-name}}
+#####################################################
+
 resource_types:
 - name: gcs
   type: docker-image
   source:
     repository: frodenas/gcs-resource
+
+- name: terraform
+  type: docker-image
+  source:
+    repository: ljfranklin/terraform-resource
+    tag: 0.11.14
 
 resources:
 # Image Resources
@@ -32,12 +114,48 @@ resources:
   source:
     branch: 6X_STABLE
     uri: https://github.com/greenplum-db/gpdb.git
+    ignore_paths:
+    - gpdb-doc/*
+    - README*
 
 - name: GreenplumR_src
   type: git
   source:
     branch: master
     uri: https://github.com/greenplum-db/GreenplumR.git
+
+# ccp_src tag_filter is not maintained by gpdb_common-ci-secrets.yml
+# so we just pull the laster ccp_src without tag_filter
+- name: ccp_src
+  type: git
+  source:
+    branch: {{ccp-git-branch}}
+    private_key: {{ccp-git-key}}
+    uri: {{ccp-git-remote}}
+
+- name: plcontainer_src
+  type: git
+  source:
+    branch: ((plcontainer-branch))
+    uri: https://github.com/greenplum-db/plcontainer.git
+
+- name: terraform
+  type: terraform
+  source:
+    env:
+      AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
+      AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+      GOOGLE_CREDENTIALS: {{google-service-account-key}}
+    vars:
+      project_id: {{google-project-id}}
+    storage:
+      access_key_id: {{tf-machine-access-key-id}}
+      secret_access_key: {{tf-machine-secret-access-key}}
+      region_name: {{aws-region}}
+      # This is not parameterized, on purpose. All tfstates will go to this spot,
+      # and different teams will place there clusters' tfstate files under different paths
+      bucket: {{tf-bucket-name}}
+      bucket_path: clusters-google/
 
 - name: bin_gpdb_centos7
   type: gcs
@@ -66,6 +184,28 @@ resources:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: plr/released/gpdb6/plr-(.*)-ubuntu18.04_x86_64.gppkg
+
+- name: plcontainer_docker_image_centos_r
+  type: gcs
+  source:
+    bucket: {{gcs-bucket-intermediates}}
+    json_key: {{concourse-gcs-resources-service-account-key}}
+    versioned_file: plcontainer/published/gpdb6/plcontainer-r-images-devel.tar.gz
+
+- name: bin_plcontainer_centos7
+  type: gcs
+  source:
+    bucket: {{gcs-bucket-intermediates}}
+    json_key: {{concourse-gcs-resources-service-account-key}}
+    versioned_file: plcontainer/published/gpdb6/plcontainer-concourse-centos7.gppkg
+
+- name: bin_plcontainer_ubuntu18
+  type: gcs
+  source:
+    bucket: {{gcs-bucket-intermediates}}
+    json_key: {{concourse-gcs-resources-service-account-key}}
+    versioned_file: plcontainer/published/gpdb6/plcontainer-concourse-ubuntu18.gppkg
+
 
 jobs:
 - name: test_plr_light_centos7
@@ -131,4 +271,85 @@ jobs:
     image: ubuntu18-image-test
     params:
       MODE: full
+
+# test GrenplumR for plcontainer
+- name: test_plcontainer_centos7
+  plan:
+  - aggregate:
+    - get: plcontainer_src
+    - get: GreenplumR_src
+    # this name is needed by ccp to gencluster
+    - get: gpdb_binary
+      resource: bin_gpdb_centos7
+    - get: ccp_src
+    - get: centos-gpdb-dev-7
+    - get: plcontainer_rclient_docker_image
+      resource: plcontainer_docker_image_centos_r
+      trigger: true
+    - get: bin_plcontainer
+      resource: bin_plcontainer_centos7
+      trigger: true
+  - put: terraform
+    params:
+      <<: *ccp_default_params
+      vars:
+        <<: *ccp_default_vars
+        PLATFORM: centos7
+  - task: gen_cluster
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gen_cluster_default_params
+      PLATFORM: centos7
+  - task: gpinitsystem
+    file: ccp_src/ci/tasks/gpinitsystem.yml
+  - task: test_greenplumr_plcontainer
+    file: GreenplumR_src/concourse/tasks/test_plcontainer.yml
+    params:
+      MODE: full
+      platform: centos7
+    image: centos-gpdb-dev-7
+    on_success:
+      <<: *ccp_destroy
+  ensure:
+    <<: *set_failed
+
+- name: test_plcontainer_ubuntu18
+  plan:
+  - aggregate:
+    - get: plcontainer_src
+    - get: GreenplumR_src
+    # this name is needed by ccp to gencluster
+    - get: gpdb_binary
+      resource: bin_gpdb_ubuntu18
+    - get: ccp_src
+    - get: ubuntu18-image-test
+    - get: plcontainer_rclient_docker_image
+      resource: plcontainer_docker_image_centos_r
+      trigger: true
+    - get: bin_plcontainer
+      resource: bin_plcontainer_ubuntu18
+      trigger: true
+  - put: terraform
+    params:
+      <<: *ccp_default_params
+      vars:
+        <<: *ccp_default_vars
+        PLATFORM: ubuntu18.04
+  - task: gen_cluster
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    params:
+      <<: *ccp_gen_cluster_default_params
+      PLATFORM: ubuntu18.04
+  - task: gpinitsystem
+    file: ccp_src/ci/tasks/gpinitsystem.yml
+  - task: test_greenplumr_plcontainer
+    file: GreenplumR_src/concourse/tasks/test_plcontainer.yml
+    params:
+      MODE: full
+      platform: ubuntu18
+    image: ubuntu18-image-test
+    on_success:
+      <<: *ccp_destroy
+  ensure:
+    <<: *set_failed
 

--- a/concourse/scripts/debug_plcontainer.sh
+++ b/concourse/scripts/debug_plcontainer.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -exo pipefail
+# this script is used to quickly run tests when pipeline failed
+CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MODE=${MODE} PGPORT=5432 bash ${CWDIR}/run_test_plcontainer.sh

--- a/concourse/scripts/run_test_plcontainer.sh
+++ b/concourse/scripts/run_test_plcontainer.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -l
+set -eox pipefail
+
+# light or full
+MODE=${MODE:=light}
+
+function test_run() {
+  cat > /home/gpadmin/test_run.sh <<-EOF
+#!/bin/bash -l
+set -exo pipefail
+export GPRLANGUAGE=plcontainer
+pushd ~/GreenplumR_src
+  if [ "$MODE" == "light" ] ; then
+    echo "library(testthat)" > test_script.R
+    echo "testthat::test_dir('tests', reporter = 'fail', stop_on_failure = TRUE)" >> test_script.R
+    R --no-save < test_script.R
+  else
+    R CMD check .
+  fi
+popd
+EOF
+
+  chmod a+x /home/gpadmin/test_run.sh
+  bash /home/gpadmin/test_run.sh
+}
+
+# run tests (light/full)
+function _main() {
+    time test_run
+}
+
+_main "$@"

--- a/concourse/scripts/test_plcontainer.sh
+++ b/concourse/scripts/test_plcontainer.sh
@@ -1,0 +1,74 @@
+#!/bin/bash -l
+set -exo pipefail
+
+ccp_src/scripts/setup_ssh_to_cluster.sh
+#############################################################
+# install docker
+#############################################################
+plcontainer_src/concourse/scripts/docker_install.sh
+
+#############################################################
+# install plcontainer
+#############################################################
+
+scp -r bin_plcontainer mdw:/tmp/
+
+ssh mdw "bash -c \" \
+set -eox pipefail; \
+export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1; \
+source /usr/local/greenplum-db-devel/greenplum_path.sh; \
+gppkg -i /tmp/bin_plcontainer/plcontainer*.gppkg; \
+\""
+
+
+#############################################################
+# install docker image
+#############################################################
+scp -r plcontainer_rclient_docker_image/plcontainer-*.tar.gz \
+    mdw:/usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-r-images.tar.gz
+
+ssh mdw "bash -c \" \
+set -eox pipefail; \
+export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1; \
+source /usr/local/greenplum-db-devel/greenplum_path.sh; \
+plcontainer image-add -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-r-images.tar.gz; \
+plcontainer runtime-add -r plc_r_shared -i pivotaldata/plcontainer_r_shared:devel -l r -s use_container_logging=yes; \
+gpstop -arf; \
+createdb rtest; \
+createdb d_apply; \
+createdb d_tapply; \
+\""
+#############################################################
+# run tests
+#############################################################
+scp -r GreenplumR_src mdw:~/
+
+# install dependencies
+case "$platform" in
+centos*)
+    node=centos
+    ;;
+ubuntu*)
+    node=ubuntu
+    ;;
+*)
+    echo "unknown platform: $platform"
+    exit 1
+    ;;
+esac
+
+ssh $node@mdw "sudo bash -c \" \
+set -eox pipefail; \
+export MODE=${MODE}; \
+bash /home/gpadmin/GreenplumR_src/concourse/scripts/test_plcontainer_prepare.sh; \
+\""
+
+ssh mdw "bash -c \" \
+set -eox pipefail; \
+export PGPORT=5432; \
+export MODE=${MODE}; \
+pushd GreenplumR_src; \
+bash concourse/scripts/run_test_plcontainer.sh
+popd; \
+\""
+#############################################################

--- a/concourse/scripts/test_plcontainer_prepare.sh
+++ b/concourse/scripts/test_plcontainer_prepare.sh
@@ -1,0 +1,78 @@
+#!/bin/bash -l
+set -eox pipefail
+# install dependencies of GreenplumR
+
+CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TOP_DIR=${CWDIR}/../../../
+# light or full
+MODE=${MODE:=light}
+
+function determine_os() {
+    if [ -f /etc/redhat-release ] ; then
+      echo "centos"
+      return
+    fi
+    if grep -q ID=ubuntu /etc/os-release ; then
+      echo "ubuntu"
+      return
+    fi
+    echo "Could not determine operating system type" >/dev/stderr
+    exit 1
+}
+
+function install_libraries() {
+    install_libraries_${MODE}
+}
+function install_libraries_min() {
+    # install system libraries
+    TEST_OS=$(determine_os)
+    case $TEST_OS in
+    centos)
+      yum install -y epel-release
+      # postgresql-devel is needed by RPostgreSQL
+      yum install -y R postgresql-devel
+      ;;
+    ubuntu)
+      apt update
+      DEBIAN_FRONTEND=noninteractive apt install -y r-base libpq-dev
+      ;;
+    *)
+      echo "unknown TEST_OS = $TEST_OS"
+      exit 1
+      ;;
+    esac
+    # install r libraries
+    ${CWDIR}/install_r_package.R testthat
+    ${CWDIR}/install_r_package.R RPostgreSQL
+    ${CWDIR}/install_r_package.R shiny
+    ${CWDIR}/install_r_package.R ini
+}
+
+function install_libraries_full() {
+  install_libraries_min
+  # install system libraries
+  case $TEST_OS in
+  centos)
+    # no more packages need to install
+    ;;
+  ubuntu)
+    DEBIAN_FRONTEND=noninteractive apt install -y pkg-config \
+        texlive-latex-base texlive-fonts-extra
+    ;;
+  esac
+  # install additional r libraries
+}
+
+function install_libraries_light() {
+    install_libraries_min
+    tar czf ${TOP_DIR}/GreenplumR.tar.gz ${TOP_DIR}/GreenplumR_src
+    R CMD INSTALL ${TOP_DIR}/GreenplumR.tar.gz
+}
+
+# install libraries (light/full)
+function _main() {
+    time install_libraries
+}
+
+_main "$@"
+

--- a/concourse/scripts/test_plr.sh
+++ b/concourse/scripts/test_plr.sh
@@ -35,13 +35,14 @@ export GPRLANGUAGE=plr
 pushd ${TOP_DIR}/GreenplumR_src
   # clear environment introduced by gpdb that may affect R
   sleep 3
+  export PGPORT=15432
   export PATH=${OLDPATH}
   unset R_HOME
   unset R_LIBS_USER
   unset LD_LIBRARY_PATH
   if [ "$MODE" == "light" ] ; then
     echo "library(testthat)" > test_script.R
-    echo "testthat::test_dir('tests', reporter = 'stop', stop_on_failure = TRUE)" >> test_script.R
+    echo "testthat::test_dir('tests', reporter = 'fail', stop_on_failure = TRUE)" >> test_script.R
     R --no-save < test_script.R
   else
     R CMD check .

--- a/concourse/tasks/test_plcontainer.yml
+++ b/concourse/tasks/test_plcontainer.yml
@@ -1,0 +1,22 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+
+inputs:
+  - name: GreenplumR_src
+  - name: plcontainer_src
+  - name: ccp_src
+  - name: gpdb_binary
+  - name: bin_plcontainer
+  - name: plcontainer_rclient_docker_image
+  - name: cluster_env_files
+
+outputs:
+
+run:
+  path: GreenplumR_src/concourse/scripts/test_plcontainer.sh
+
+params:
+  MODE:
+

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -10,7 +10,9 @@ env <- new.env(parent = globalenv())
 
 .host <- 'localhost'
 .dbname <- "rtest"
-.port <- 15432
+.port <- strtoi(Sys.getenv('PGPORT'))
+if (is.na(.port))
+    stop("PGPORT not set")
 .language <- tolower(Sys.getenv('GPRLANGUAGE'))
 if (.language != 'plr' && .language != 'plcontainer')
     stop(paste0("invalid GPRLANGUAGE:", .language))

--- a/tests/testthat/test-gpapply.R
+++ b/tests/testthat/test-gpapply.R
@@ -11,7 +11,9 @@ env <- new.env(parent = globalenv())
 
 .host <- 'localhost'
 .dbname <- "d_apply"
-.port <- 15432
+.port <- strtoi(Sys.getenv('PGPORT'))
+if (is.na(.port))
+    stop("PGPORT not set")
 .language <- tolower(Sys.getenv('GPRLANGUAGE'))
 if (.language != 'plr' && .language != 'plcontainer')
     stop(paste0("invalid GPRLANGUAGE:", .language))

--- a/tests/testthat/test-gptapply.R
+++ b/tests/testthat/test-gptapply.R
@@ -11,7 +11,9 @@ env <- new.env(parent = globalenv())
 
 .host <- 'localhost'
 .dbname <- "d_tapply"
-.port <- 15432
+.port <- strtoi(Sys.getenv('PGPORT'))
+if (is.na(.port))
+    stop("PGPORT not set")
 .language <- tolower(Sys.getenv('GPRLANGUAGE'))
 if (.language != 'plr' && .language != 'plcontainer')
     stop(paste0("invalid GPRLANGUAGE:", .language))


### PR DESCRIPTION
Add pipelines for both centos7 and ubuntu18.04
light mode doesn't work for plcontainer, since
test failure doesn't make pipeline red.

Co-authored-by: Hao Wu <hawu@pivotal.io>
Co-authored-by: Xinyue Ge <xge@pivotal.io>