### PR TITLE
Add new parameter in gpapply/gptapply

### DIFF
--- a/R/db.gpapply.R
+++ b/R/db.gpapply.R
@@ -79,9 +79,8 @@ db.gpapply <- function(X, MARGIN = NULL, FUN = NULL, output.name = NULL,
         }
         
         quoted.fields.list <- .quoted.fields.list(ar$.col.name)
-        if (is.null(input.signature)) {
-            localArgsStr <- args.str
-        } else {
+		localArgsStr <- NULL
+        if (!is.null(input.signature)) {
             localArgsStr <- .create.inputArgs(input.signature)
         }
 
@@ -89,7 +88,7 @@ db.gpapply <- function(X, MARGIN = NULL, FUN = NULL, output.name = NULL,
         createStmt <- .create.r.wrapper2(basename=basename, FUN=FUN,
                                 selected.type.list = .selected.type.list(ar),
                                 selected.equal.list = .selected.equal.list(ar$.col.name),
-                                user.args.str = localArgsStr, runtime.id=runtime.id,
+                                user.args.str = args.str, input.args.str = localArgsStr, runtime.id=runtime.id,
                                 language=language)
         db.q(createStmt, verbose = debugger.mode)
 
@@ -103,7 +102,7 @@ db.gpapply <- function(X, MARGIN = NULL, FUN = NULL, output.name = NULL,
                             typeName = typeName,
                             clear.existing = clear.existing,
                             distribute.str = distribute.str)
-
+        print(query)
         results <- db.q(query, nrows = NULL, verbose = debugger.mode)
 
     #END OF tryCatch

--- a/R/db.gpapply.R
+++ b/R/db.gpapply.R
@@ -79,8 +79,11 @@ db.gpapply <- function(X, MARGIN = NULL, FUN = NULL, output.name = NULL,
         }
         
         quoted.fields.list <- .quoted.fields.list(ar$.col.name)
-		localArgsStr <- .create.inputArgs(input.signature)
-
+        if (is.null(input.signature)) {
+            localArgsStr <- args.str
+        } else {
+            localArgsStr <- .create.inputArgs(input.signature)
+        }
 
         # Create function
         createStmt <- .create.r.wrapper2(basename=basename, FUN=FUN,

--- a/R/db.gpapply.R
+++ b/R/db.gpapply.R
@@ -33,7 +33,7 @@ db.gpapply <- function(X, MARGIN = NULL, FUN = NULL, output.name = NULL,
                         output.signature = NULL, clear.existing = FALSE,
                         case.sensitive = FALSE, output.distributeOn = NULL,
                         debugger.mode = FALSE, runtime.id = "plc_r_shared",
-                        language = "plcontainer", ...)
+                        language = "plcontainer", input.signature = NULL, ...)
 {
     if (is.null(X) || !is.db.data.frame(X))
         stop("X must be a db.data.frame")
@@ -79,13 +79,14 @@ db.gpapply <- function(X, MARGIN = NULL, FUN = NULL, output.name = NULL,
         }
         
         quoted.fields.list <- .quoted.fields.list(ar$.col.name)
+		localArgsStr <- .create.inputArgs(input.signature)
 
 
         # Create function
         createStmt <- .create.r.wrapper2(basename=basename, FUN=FUN,
                                 selected.type.list = .selected.type.list(ar),
                                 selected.equal.list = .selected.equal.list(ar$.col.name),
-                                user.args.str=args.str, runtime.id=runtime.id,
+                                user.args.str = localArgsStr, runtime.id=runtime.id,
                                 language=language)
         db.q(createStmt, verbose = debugger.mode)
 

--- a/R/db.gptapply.R
+++ b/R/db.gptapply.R
@@ -94,10 +94,9 @@ db.gptapply <- function(X, INDEX, FUN = NULL, output.name = NULL, output.signatu
                 param.type.list <- .to.type.field(ar$.col.name[i], ar$.col.udt_name[i], .isIndex)
             }
         }
-
-        if (is.null(input.signature)) {
-            localArgsStr <- args.str
-        } else {
+        
+		localArgsStr <- NULL
+        if (!is.null(input.signature)) {
             localArgsStr <- .create.inputArgs(input.signature)
         }
         
@@ -106,7 +105,7 @@ db.gptapply <- function(X, INDEX, FUN = NULL, output.name = NULL, output.signatu
                                     selected.type.list = param.type.list,
                                     # selected column from table X, it may be optimized
                                     selected.equal.list = .selected.equal.list(ar$.col.name),
-                                    user.args.str = args.str, runtime.id = runtime.id,
+                                    user.args.str = args.str, input.args.str = localArgsStr, runtime.id = runtime.id,
                                     language = language)
         db.q(createStmt, verbose = debugger.mode)
 

--- a/R/db.gptapply.R
+++ b/R/db.gptapply.R
@@ -33,7 +33,8 @@
 db.gptapply <- function(X, INDEX, FUN = NULL, output.name = NULL, output.signature = NULL,
                         clear.existing = FALSE, case.sensitive = FALSE,
                         output.distributeOn = NULL, debugger.mode = FALSE,
-                        runtime.id = "plc_r_shared", language = "plcontainer", ...)
+                        runtime.id = "plc_r_shared", language = "plcontainer",
+                        input.signature = NULL, ...)
 {
     # handle case when colnames of X are not all lower, and case.sensitive = FALSE
     if (is.null(X) || !is.db.data.frame(X))
@@ -92,6 +93,12 @@ db.gptapply <- function(X, INDEX, FUN = NULL, output.name = NULL, output.signatu
                 param.group.list <- .to.group.field(ar$.col.name[i], .isIndex)
                 param.type.list <- .to.type.field(ar$.col.name[i], ar$.col.udt_name[i], .isIndex)
             }
+        }
+
+        if (is.null(input.signature)) {
+            localArgsStr <- args.str
+        } else {
+            localArgsStr <- .create.inputArgs(input.signature)
         }
         
         #Create function

--- a/R/utility-apply.R
+++ b/R/utility-apply.R
@@ -124,6 +124,28 @@
     return (typelist_str)
 }
 
+.create.inputArgs <- function(signature_list, case.sensitive=FALSE)
+{
+    if (is.null(signature_list))
+      return (NULL)
+
+    #CASE_SENSITIVE:  signature_list
+    typelist <- .simplify.signature(signature_list)
+
+    if (isTRUE(case.sensitive)){
+        if (isTRUE(any(duplicated(names(typelist)))))
+            stop(paste("duplicated signature:", paste(names(typelist), collapse=", ")))
+        argStr <- paste(names(typelist), " =  ", typelist, sep="", collapse=", ")
+    }
+    else{
+        if (isTRUE(any(duplicated(tolower(names(typelist))))))
+            stop(paste("duplicated signature:", paste(names(typelist), collapse=", ")))
+        argStr <- paste(names(typelist), " =  ", typelist, sep="", collapse=", ")
+    }
+
+    return (argStr)
+}
+
 getRandomNameList <- function(n = 1)
 {
     a <- do.call(paste0, replicate(5, sample(LETTERS, n, TRUE), FALSE))
@@ -169,10 +191,12 @@ getRandomNameList <- function(n = 1)
     # check the userCode is correct or not
     parse(text = userCode) 
     funBody <- sprintf("# container: %s \ngplocalf <- %s", runtime.id, userCode)
-    localdf <- sprintf("df <- data.frame(%s)", selected.equal.list)
-    localcall <- sprintf("do.call(gplocalf, list(df%s))", user.args.str)
+    #localdf <- sprintf("df <- data.frame(%s)", selected.equal.list)
+    localcall <- sprintf("gplocalf(%s)", user.args.str)
 
-    createStmt <- sprintf("CREATE FUNCTION %s (%s) RETURNS SETOF %s AS $$\n %s\n %s\nreturn(%s)\n $$ LANGUAGE '%s';",
-                          funName, selected.type.list, typeName, funBody, localdf, localcall, language)
+    #createStmt <- sprintf("CREATE FUNCTION %s (%s) RETURNS SETOF %s AS $$\n %s\n %s\nreturn(%s)\n $$ LANGUAGE '%s';",
+    #                      funName, selected.type.list, typeName, funBody, localdf, localcall, language)
+    createStmt <- sprintf("CREATE FUNCTION %s (%s) RETURNS SETOF %s AS $$\n %s\n return(%s)\n $$ LANGUAGE '%s';",
+                          funName, selected.type.list, typeName, funBody, localcall, language)
     return (createStmt)
 }

--- a/man/db.gpapply.Rd
+++ b/man/db.gpapply.Rd
@@ -12,7 +12,8 @@
 \usage{
 db.gpapply(X, MARGIN = NULL, FUN = NULL, output.name = NULL, output.signature = NULL,
             clear.existing = FALSE, case.sensitive = FALSE, output.distributeOn = NULL,
-            debugger.mode = FALSE, runtime.id = "plc_r_shared", language = "plcontainer", ...)
+            debugger.mode = FALSE, runtime.id = "plc_r_shared", language = "plcontainer", 
+            input.signature = NULL, ...)
 }
 
 \arguments{
@@ -45,6 +46,14 @@ db.gpapply(X, MARGIN = NULL, FUN = NULL, output.name = NULL, output.signature = 
     e.g. output.signature <- list(id = 'int', 'Sex' = 'text', 'Length' = 'float', height = 'float', shell = 'float')
     or output.signature <- function() list(id = 'int')
   }
+
+  \item{input.signature}{
+    The parameter to match the applying function arguments and table columns' name
+    The pair is function arguments name = table column name
+    e.g. input.signature <- list('arg_f_1' = 'arg_t_1', 'arg_f_2' = 'arg_t_2')
+    NOTICE: The order of both arguments must not change
+  }
+
 
   \item{case.sensitive}{
     Whether output.name, colnames of input tables are case sensitive

--- a/man/db.gptapply.Rd
+++ b/man/db.gptapply.Rd
@@ -16,7 +16,8 @@
 db.gptapply(X, INDEX, FUN = NULL, output.name = NULL, output.signature = NULL,
             clear.existing = FALSE, case.sensitive = FALSE,
             output.distributeOn = NULL, debugger.mode = FALSE,
-            runtime.id = "plc_r_shared", language = "plcontainer", ...)
+            runtime.id = "plc_r_shared", language = "plcontainer", 
+            input.signature = NULL, ...)
 }
 
 \arguments{
@@ -43,6 +44,13 @@ db.gptapply(X, INDEX, FUN = NULL, output.name = NULL, output.signature = NULL,
   \item{output.signature}{
     The parameter of output table
     e.g. output.signature <- list(id = 'int', 'Sex' = 'text', 'Length' = 'float', height = 'float', shell = 'float')
+  }
+
+  \item{input.signature}{
+      The parameter to match the applying function arguments and table columns' name
+      The pair is function arguments name = table column name
+      e.g. input.signature <- list('arg_f_1' = 'arg_t_1', 'arg_f_2' = 'arg_t_2')
+      NOTICE: The order of both arguments must not change
   }
 
   \item{case.sensitive}{


### PR DESCRIPTION
1. Add new parameter input.signature in gpapply/gptapply, this parameter is used for matching the applying function arguments and table columns' names if the applying function inputs are not single data.frame.

```
# no need  input.signature
rfunction(data.frame)

# need  input.signature
rfunction(table_column1, table_column2, ...)
```